### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/bsd/dma-mbox-create/Makefile
+++ b/bsd/dma-mbox-create/Makefile
@@ -11,6 +11,7 @@ PROG=	dma-mbox-create
 .PATH: ${.CURDIR}/../..
 SRCS+=	dma-mbox-create.c
 NOMAN=
+MK_MAN=	no
 
 PREFIX?=	/usr/local
 LIBEXEC?=	${PREFIX}/libexec


### PR DESCRIPTION
Currently dma fails to build on FreeBSD with following error:

make[1]: don't know how to make dma-mbox-create.1. Stop

Setting proper MK_MAN variable fixes this.