### PR TITLE
resolves corecode/dma#30

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -68,7 +68,6 @@ add_host(int pref, const char *host, int port, struct mx_hostentry **he, size_t 
 	char servname[10];
 	struct mx_hostentry *p;
 	const int count_inc = 10;
-	int err;
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = PF_UNSPEC;
@@ -76,9 +75,26 @@ add_host(int pref, const char *host, int port, struct mx_hostentry **he, size_t 
 	hints.ai_protocol = IPPROTO_TCP;
 
 	snprintf(servname, sizeof(servname), "%d", port);
-	err = getaddrinfo(host, servname, &hints, &res0);
-	if (err)
-		return (err == EAI_AGAIN ? 1 : -1);
+	switch (getaddrinfo(host, servname, &hints, &res0)) {
+	case 0:
+		break;
+	case EAI_AGAIN:
+	case EAI_NONAME:
+		/*
+		 * EAI_NONAME gets returned for:
+		 * SMARTHOST set but DNS server not reachable -> defer
+		 * SMARTHOST set but DNS server returns "host does not exist"
+		 *           -> buggy configuration
+		 *           -> either defer or bounce would be ok -> defer
+		 * MX entry was returned by DNS server but name doesn't resolve
+		 *           -> hopefully transient situation -> defer
+		 * all other DNS problems should have been caught earlier
+		 * in dns_get_mx_list().
+		 */
+		goto out;
+	default:
+		return(-1);
+	}
 
 	for (res = res0; res != NULL; res = res->ai_next) {
 		if (*ps + 1 >= roundup(*ps, count_inc)) {

--- a/dns.c
+++ b/dns.c
@@ -78,7 +78,7 @@ add_host(int pref, const char *host, int port, struct mx_hostentry **he, size_t 
 	snprintf(servname, sizeof(servname), "%d", port);
 	err = getaddrinfo(host, servname, &hints, &res0);
 	if (err)
-		return ((err == EAI_AGAIN || err == EAI_NONAME) ? 1 : -1);
+		return (err == EAI_AGAIN ? 1 : -1);
 
 	for (res = res0; res != NULL; res = res->ai_next) {
 		if (*ps + 1 >= roundup(*ps, count_inc)) {

--- a/dns.c
+++ b/dns.c
@@ -78,7 +78,7 @@ add_host(int pref, const char *host, int port, struct mx_hostentry **he, size_t 
 	snprintf(servname, sizeof(servname), "%d", port);
 	err = getaddrinfo(host, servname, &hints, &res0);
 	if (err)
-		return (err == EAI_AGAIN ? 1 : -1);
+		return ((err == EAI_AGAIN || err == EAI_NONAME) ? 1 : -1);
 
 	for (res = res0; res != NULL; res = res->ai_next) {
 		if (*ps + 1 >= roundup(*ps, count_inc)) {


### PR DESCRIPTION
Although this looks like a quick and dirty fix, it is not at all. I did
quite a bit of testing and digging through the code. The only
alternative would be to replace getaddrinfo() with a res_ type
fuction. FWIW I tested it on Linux and glibc, hopefully, getaddrinfo()
behaves similarly on the BSDs.
This is my commit message:
getaddrinfo() does not distinguish between "DNS server not reachable"
and "DNS server told me host does not exist". However, for sending
mail directly, both cases have been caught previously with the call
to res_search(). Only when looking up the IP address of the smart host,
getaddrinfo() can return an EAI_NONAME. In that case, "DNS server
not reachable" should result in deferring, and "host unknown" can
result in either bouncing or deferring since in the end it is a
setup error and logs need to be checked anyways.