### PR TITLE
Implement better authentication

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -77,7 +77,7 @@ init_cert_file(SSL_CTX *ctx, const char *path)
 }
 
 int
-smtp_init_crypto(int fd, int feature)
+smtp_init_crypto(int fd, int feature, struct smtp_features* features)
 {
 	SSL_CTX *ctx = NULL;
 #if (OPENSSL_VERSION_NUMBER >= 0x00909000L)
@@ -118,8 +118,7 @@ smtp_init_crypto(int fd, int feature)
 		/* TLS init phase, disable SSL_write */
 		config.features |= NOSSL;
 
-		send_remote_command(fd, "EHLO %s", hostname());
-		if (read_remote(fd, 0, NULL) == 2) {
+		if (perform_server_greeting(fd, features) == 0) {
 			send_remote_command(fd, "STARTTLS");
 			if (read_remote(fd, 0, NULL) != 2) {
 				if ((feature & TLS_OPP) == 0) {
@@ -131,6 +130,7 @@ smtp_init_crypto(int fd, int feature)
 				}
 			}
 		}
+
 		/* End of TLS init phase, enable SSL_write/read */
 		config.features &= ~NOSSL;
 	}

--- a/dma.h
+++ b/dma.h
@@ -51,6 +51,7 @@
 #define BUF_SIZE	2048
 #define ERRMSG_SIZE	200
 #define USERNAME_SIZE	50
+#define EHLO_RESPONSE_SIZE BUF_SIZE
 #define MIN_RETRY	300		/* 5 minutes */
 #define MAX_RETRY	(3*60*60)	/* retry at least every 3 hours */
 #define MAX_TIMEOUT	(5*24*60*60)	/* give up after 5 days */
@@ -160,6 +161,15 @@ struct mx_hostentry {
 	struct sockaddr_storage	sa;
 };
 
+struct smtp_auth_mechanisms {
+	int cram_md5;
+	int login;
+};
+
+struct smtp_features {
+	struct smtp_auth_mechanisms auth;
+	int starttls;
+};
 
 /* global variables */
 extern struct aliases aliases;
@@ -187,7 +197,7 @@ void parse_authfile(const char *);
 /* crypto.c */
 void hmac_md5(unsigned char *, int, unsigned char *, int, unsigned char *);
 int smtp_auth_md5(int, char *, char *);
-int smtp_init_crypto(int, int);
+int smtp_init_crypto(int, int, struct smtp_features*);
 
 /* dns.c */
 int dns_get_mx_list(const char *, int, struct mx_hostentry **, int);
@@ -196,6 +206,7 @@ int dns_get_mx_list(const char *, int, struct mx_hostentry **, int);
 char *ssl_errstr(void);
 int read_remote(int, int, char *);
 ssize_t send_remote_command(int, const char*, ...)  __attribute__((__nonnull__(2), __format__ (__printf__, 2, 3)));
+int perform_server_greeting(int, struct smtp_features*);
 int deliver_remote(struct qitem *);
 
 /* base64.c */


### PR DESCRIPTION
DMA tries to authenticate by simply trying various authentication
mechanisms. This is obviously not conforming to RFC and some mail
providers detect this is spam and reject all emails.

This patch parses the EHLO response and reads various keywords
from it that can then later in the program be used to jump into
certain code paths.

Currently this is used to only authenticate with CRAM-MD5 and/or
LOGIN if the server supports one or both of these. The
implementation can be easily be extended though.

Signed-off-by: Michael Tremer michael.tremer@ipfire.org
