### PR TITLE
Buildfix for dma on SunOS

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -40,6 +40,7 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 
+#include <strings.h>
 #include <syslog.h>
 
 #include "dma.h"

--- a/dma.c
+++ b/dma.c
@@ -54,6 +54,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <syslog.h>
 #include <unistd.h>
 
@@ -94,7 +95,7 @@ sighup_handler(int signo)
 }
 
 static char *
-set_from(struct queue *queue, const char *osender)
+set_from(struct dma_queue *queue, const char *osender)
 {
 	const char *addr;
 	char *sender;
@@ -153,7 +154,7 @@ read_aliases(void)
 }
 
 static int
-do_alias(struct queue *queue, const char *addr)
+do_alias(struct dma_queue *queue, const char *addr)
 {
 	struct alias *al;
         struct stritem *sit;
@@ -173,7 +174,7 @@ do_alias(struct queue *queue, const char *addr)
 }
 
 int
-add_recp(struct queue *queue, const char *str, int expand)
+add_recp(struct dma_queue *queue, const char *str, int expand)
 {
 	struct qitem *it, *tit;
 	struct passwd *pw;
@@ -240,7 +241,7 @@ out:
 }
 
 static struct qitem *
-go_background(struct queue *queue)
+go_background(struct dma_queue *queue)
 {
 	struct sigaction sa;
 	struct qitem *it;
@@ -372,7 +373,7 @@ bounce:
 }
 
 void
-run_queue(struct queue *queue)
+run_queue(struct dma_queue *queue)
 {
 	struct qitem *it;
 
@@ -385,7 +386,7 @@ run_queue(struct queue *queue)
 }
 
 static void
-show_queue(struct queue *queue)
+show_queue(struct dma_queue *queue)
 {
 	struct qitem *it;
 	int locked = 0;	/* XXX */
@@ -421,7 +422,7 @@ main(int argc, char **argv)
 {
 	struct sigaction act;
 	char *sender = NULL;
-	struct queue queue;
+	struct dma_queue queue;
 	int i, ch;
 	int nodot = 0, showq = 0, queue_only = 0;
 	int recp_from_header = 0;

--- a/dma.h
+++ b/dma.h
@@ -118,7 +118,7 @@ struct qitem {
 };
 LIST_HEAD(queueh, qitem);
 
-struct queue {
+struct dma_queue {
 	struct queueh queue;
 	char *id;
 	FILE *mailf;
@@ -205,16 +205,16 @@ int base64_decode(const char *, void *);
 /* dma.c */
 #define EXPAND_ADDR	1
 #define EXPAND_WILDCARD	2
-int add_recp(struct queue *, const char *, int);
-void run_queue(struct queue *);
+int add_recp(struct dma_queue *, const char *, int);
+void run_queue(struct dma_queue *);
 
 /* spool.c */
-int newspoolf(struct queue *);
-int linkspool(struct queue *);
-int load_queue(struct queue *);
+int newspoolf(struct dma_queue *);
+int linkspool(struct dma_queue *);
+int load_queue(struct dma_queue *);
 void delqueue(struct qitem *);
 int acquirespool(struct qitem *);
-void dropspool(struct queue *, struct qitem *);
+void dropspool(struct dma_queue *, struct qitem *);
 int flushqueue_since(unsigned int);
 int flushqueue_signal(void);
 
@@ -223,7 +223,7 @@ int deliver_local(struct qitem *);
 
 /* mail.c */
 void bounce(struct qitem *, const char *);
-int readmail(struct queue *, int, int);
+int readmail(struct dma_queue *, int, int);
 
 /* util.c */
 const char *hostname(void);

--- a/dns.c
+++ b/dns.c
@@ -41,7 +41,12 @@
 #include <netdb.h>
 #include <resolv.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
+
+#if defined(__sun)
+#include <sys/sysmacros.h>
+#endif
 
 #include "dma.h"
 

--- a/local.c
+++ b/local.c
@@ -45,6 +45,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <syslog.h>
+#include <strings.h>
 #include <unistd.h>
 
 #include "dma.h"

--- a/mail.c
+++ b/mail.c
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <strings.h>
 #include <syslog.h>
 #include <unistd.h>
 
@@ -44,7 +45,7 @@
 void
 bounce(struct qitem *it, const char *reason)
 {
-	struct queue bounceq;
+	struct dma_queue bounceq;
 	char line[1000];
 	size_t pos;
 	int error;
@@ -160,7 +161,7 @@ struct parse_state {
  * XXX local addresses will need treatment
  */
 static int
-parse_addrs(struct parse_state *ps, char *s, struct queue *queue)
+parse_addrs(struct parse_state *ps, char *s, struct dma_queue *queue)
 {
 	char *addr;
 
@@ -342,7 +343,7 @@ newaddr:
 }
 
 int
-readmail(struct queue *queue, int nodot, int recp_from_header)
+readmail(struct dma_queue *queue, int nodot, int recp_from_header)
 {
 	struct parse_state parse_state;
 	char line[1000];	/* by RFC2822 */

--- a/spool.c
+++ b/spool.c
@@ -46,6 +46,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <syslog.h>
+#include <strings.h>
 
 #include "dma.h"
 
@@ -69,7 +70,7 @@
  */
 
 int
-newspoolf(struct queue *queue)
+newspoolf(struct dma_queue *queue)
 {
 	char fn[PATH_MAX+1];
 	struct stat st;
@@ -151,10 +152,10 @@ writequeuef(struct qitem *it)
 }
 
 static struct qitem *
-readqueuef(struct queue *queue, char *queuefn)
+readqueuef(struct dma_queue *queue, char *queuefn)
 {
 	char line[1000];
-	struct queue itmqueue;
+	struct dma_queue itmqueue;
 	FILE *queuef = NULL;
 	char *s;
 	char *queueid = NULL, *sender = NULL, *addr = NULL;
@@ -229,7 +230,7 @@ out:
 }
 
 int
-linkspool(struct queue *queue)
+linkspool(struct dma_queue *queue)
 {
 	struct stat st;
 	struct qitem *it;
@@ -276,7 +277,7 @@ delfiles:
 }
 
 int
-load_queue(struct queue *queue)
+load_queue(struct dma_queue *queue)
 {
 	struct stat sb;
 	struct qitem *it;
@@ -382,7 +383,7 @@ fail:
 }
 
 void
-dropspool(struct queue *queue, struct qitem *keep)
+dropspool(struct dma_queue *queue, struct qitem *keep)
 {
 	struct qitem *it;
 


### PR DESCRIPTION
To build dma on SunOS (tested on SmartOS) it's required to rename existing queue struct to dma_queue (or anything else). To decrease the warnings I also included strings.h for the bzero and bcopy function. The sys/sysmacros.h include is required for the roundup function.

The following additional `LDFLAGS` are required on SunOS. I'm not sure how to reflect that in your `Makefile`:

```
-lsocket -lnsl
```

This should hopefully fix #1.