### PR TITLE
Correct semantic 'readmail' errors

### DIFF
--- a/dma.h
+++ b/dma.h
@@ -58,7 +58,7 @@
 #ifndef PATH_MAX
 #define PATH_MAX	1024		/* Max path len */
 #endif
-#define RFC822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
+#define RFC2822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
 #define DMA_LINE_MAX	2^16		/* Max email line length, internal */
 #define	SMTP_PORT	25		/* Default SMTP port */
 #define CON_TIMEOUT	(5*60)		/* Connection timeout per RFC5321 */

--- a/dma.h
+++ b/dma.h
@@ -58,6 +58,8 @@
 #ifndef PATH_MAX
 #define PATH_MAX	1024		/* Max path len */
 #endif
+#define RFC822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
+#define DMA_LINE_MAX	2^16		/* Max email line length, internal */
 #define	SMTP_PORT	25		/* Default SMTP port */
 #define CON_TIMEOUT	(5*60)		/* Connection timeout per RFC5321 */
 

--- a/local.c
+++ b/local.c
@@ -126,7 +126,7 @@ int
 deliver_local(struct qitem *it)
 {
 	char fn[PATH_MAX+1];
-	char line[1000];
+	char line[DMA_LINE_MAX];
 	const char *sender;
 	const char *newline = "\n";
 	size_t linelen;

--- a/mail.c
+++ b/mail.c
@@ -45,7 +45,7 @@ void
 bounce(struct qitem *it, const char *reason)
 {
 	struct queue bounceq;
-	char line[1000];
+	char line[DMA_LINE_MAX];
 	size_t pos;
 	int error;
 
@@ -137,7 +137,7 @@ fail:
 }
 
 struct parse_state {
-	char addr[1000];
+	char addr[DMA_LINE_MAX];	/* will not be larger than input line */
 	int pos;
 
 	enum {
@@ -345,7 +345,7 @@ int
 readmail(struct queue *queue, int nodot, int recp_from_header)
 {
 	struct parse_state parse_state;
-	char line[1000];	/* by RFC2822 */
+	char line[DMA_LINE_MAX];
 	size_t linelen;
 	size_t error;
 	int had_headers = 0;

--- a/mail.c
+++ b/mail.c
@@ -345,7 +345,7 @@ int
 readmail(struct queue *queue, int nodot, int recp_from_header)
 {
 	struct parse_state parse_state;
-	char line[DMA_LINE_MAX];
+	char line[DMA_LINE_MAX+1];	/* allow 'fgets' to append an '\0' */
 	size_t linelen;
 	size_t error;
 	int had_headers = 0;
@@ -379,12 +379,14 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 				" from %s (uid %d) (envelope-from %s)",
 				username, useruid, queue->sender);
 		linelen = strlen(line);
-		if (linelen == 0 || line[linelen - 1] != '\n') {
+		if (linelen == 0 || line[linelen - 2] != '\r' || line[linelen - 1] != '\n') ) {
 			/*
-			 * This line did not end with a newline character.
-			 * If we fix it, it better be the last line of
+			 * This line did not end with a CRLF, cludge it.
+			 * If we fixed it, it better be the last line of
 			 * the file.
+			 * XXX: overwriting valid input is probably an inadequate cludge here
 			 */
+			line[linelen-1] = '\r';
 			line[linelen] = '\n';
 			line[linelen + 1] = 0;
 			had_last_line = 1;

--- a/net.c
+++ b/net.c
@@ -352,7 +352,7 @@ static int
 deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
-	char line[1000];
+	char line[RFC822_LINE_MAX];
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 

--- a/net.c
+++ b/net.c
@@ -352,7 +352,7 @@ static int
 deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
-	char line[RFC822_LINE_MAX];
+	char line[RFC2822_LINE_MAX];
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 

--- a/spool.c
+++ b/spool.c
@@ -153,7 +153,7 @@ writequeuef(struct qitem *it)
 static struct qitem *
 readqueuef(struct queue *queue, char *queuefn)
 {
-	char line[1000];
+	char line[DMA_LINE_MAX];
 	struct queue itmqueue;
 	FILE *queuef = NULL;
 	char *s;


### PR DESCRIPTION
Silly patch really for silly bug (corecode/dma#43).  Corrects both a buffer mis-calculation (probably benign) and creates a CRLF terminator for overly long-lines / unterminated messages (instead of just a LF terminator).  It actually still doesn't perform adequate checking (as noted) but it's probably good enough[tm].