### PR TITLE
Allow input line length to exceed RFC2822 limit

### DIFF
--- a/dma.h
+++ b/dma.h
@@ -58,7 +58,7 @@
 #ifndef PATH_MAX
 #define PATH_MAX	1024		/* Max path len */
 #endif
-#define RFC822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
+#define RFC2822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
 #define DMA_LINE_MAX	2^16		/* Max email line length, internal */
 #define	SMTP_PORT	25		/* Default SMTP port */
 #define CON_TIMEOUT	(5*60)		/* Connection timeout per RFC5321 */

--- a/dma.h
+++ b/dma.h
@@ -59,7 +59,7 @@
 #define PATH_MAX	1024		/* Max path len */
 #endif
 #define RFC2822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
-#define DMA_LINE_MAX	2^16		/* Max email line length, internal */
+#define DMA_LINE_MAX	65536		/* Max email line length, internal */
 #define	SMTP_PORT	25		/* Default SMTP port */
 #define CON_TIMEOUT	(5*60)		/* Connection timeout per RFC5321 */
 

--- a/dma.h
+++ b/dma.h
@@ -58,6 +58,8 @@
 #ifndef PATH_MAX
 #define PATH_MAX	1024		/* Max path len */
 #endif
+#define RFC822_LINE_MAX	1000		/* Max email line length, per RFC2822 */
+#define DMA_LINE_MAX	2^16		/* Max email line length, internal */
 #define	SMTP_PORT	25		/* Default SMTP port */
 #define CON_TIMEOUT	(5*60)		/* Connection timeout per RFC5321 */
 

--- a/local.c
+++ b/local.c
@@ -126,7 +126,7 @@ int
 deliver_local(struct qitem *it)
 {
 	char fn[PATH_MAX+1];
-	char line[1000];
+	char line[DMA_LINE_MAX];
 	const char *sender;
 	const char *newline = "\n";
 	size_t linelen;

--- a/mail.c
+++ b/mail.c
@@ -45,7 +45,7 @@ void
 bounce(struct qitem *it, const char *reason)
 {
 	struct queue bounceq;
-	char line[1000];
+	char line[DMA_LINE_MAX];
 	size_t pos;
 	int error;
 
@@ -137,7 +137,7 @@ fail:
 }
 
 struct parse_state {
-	char addr[1000];
+	char addr[DMA_LINE_MAX];	/* will not be larger than input line */
 	int pos;
 
 	enum {
@@ -345,7 +345,7 @@ int
 readmail(struct queue *queue, int nodot, int recp_from_header)
 {
 	struct parse_state parse_state;
-	char line[1000];	/* by RFC2822 */
+	char line[DMA_LINE_MAX];
 	size_t linelen;
 	size_t error;
 	int had_headers = 0;

--- a/net.c
+++ b/net.c
@@ -352,7 +352,7 @@ static int
 deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
-	char line[1000];
+	char line[RFC822_LINE_MAX];
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 

--- a/net.c
+++ b/net.c
@@ -352,7 +352,7 @@ static int
 deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
-	char line[RFC822_LINE_MAX];
+	char line[RFC2822_LINE_MAX];
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 

--- a/spool.c
+++ b/spool.c
@@ -153,7 +153,7 @@ writequeuef(struct qitem *it)
 static struct qitem *
 readqueuef(struct queue *queue, char *queuefn)
 {
-	char line[1000];
+	char line[DMA_LINE_MAX];
 	struct queue itmqueue;
 	FILE *queuef = NULL;
 	char *s;


### PR DESCRIPTION
This is my initial hack at patching corecode/dma#18. It basically defines two different buffer lengths, one for the received message (DMA_LINE_MAX) and one for sent messages (RFC2822_LINE_MAX); thus it moves the current error from a receipt error to a transmission error.