### PR TITLE
different behavior when called as "mailq" then "/usr/bin/mailq

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -47,6 +47,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <libgen.h>
 #include <paths.h>
 #include <pwd.h>
 #include <signal.h>
@@ -457,7 +458,7 @@ main(int argc, char **argv)
 	bzero(&queue, sizeof(queue));
 	LIST_INIT(&queue.queue);
 
-	if (strcmp(argv[0], "mailq") == 0) {
+	if (strcmp(basename(argv[0]), "mailq") == 0) {
 		argv++; argc--;
 		showq = 1;
 		if (argc != 0)


### PR DESCRIPTION
We ran into problems calling dma (on FreeBSD) from the nagios check_mailq script, and found out that it behaves correctly when called as just "mailq", but incorrectly when called as "/usr/bin/mailq" (with a path) for example. This patch written by my colleague Klaus-Uwe Ittner corrects this.

Also reported as https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=216910.