### PR TITLE
dma.conf: fix a typo in a comment.

### DIFF
--- a/dma.conf
+++ b/dma.conf
@@ -18,7 +18,7 @@
 # SMTP authentication
 #AUTHPATH /etc/dma/auth.conf
 
-# Uncomment if yout want TLS/SSL support
+# Uncomment if you want TLS/SSL support
 #SECURETRANSFER
 
 # Uncomment if you want STARTTLS support (only used in combination with


### PR DESCRIPTION
Sponsored by:	The FreeBSD Foundation