### PR TITLE
net.c: Include string.h

### DIFF
--- a/net.c
+++ b/net.c
@@ -53,6 +53,7 @@
 #include <netdb.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <string.h>
 #include <syslog.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Various functions that have been used come from string.h. GCC compiled
dma without this header, but unfortunately the binary segfaulted at random
times.

Signed-off-by: Michael Tremer <michael.tremer@ipfire.org>