### PR TITLE
Add support for RFC976 "From_ lines

### DIFF
--- a/mail.c
+++ b/mail.c
@@ -393,6 +393,10 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 			had_last_line = 1;
 		}
 		if (!had_first_line) {
+			/*
+			 * Ignore a leading RFC-976 From_ or >From_ line mistakenly
+			 * inserted by some programs.
+			 */
 			if (strprefixcmp(line, "From ") == 0 || strprefixcmp(line, ">From ") == 0)
 				continue;
 			had_first_line = 1;

--- a/mail.c
+++ b/mail.c
@@ -354,9 +354,9 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 	int had_from = 0;
 	int had_messagid = 0;
 	int had_date = 0;
+	int had_first_line = 0;
 	int had_last_line = 0;
 	int nocopy = 0;
-	int had_firstline = 0;
 
 	parse_state.state = NONE;
 
@@ -392,10 +392,10 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 			line[linelen + 1] = 0;
 			had_last_line = 1;
 		}
-		if (!had_firstline) {
-			had_firstline = 1;
+		if (!had_first_line) {
 			if (strprefixcmp(line, "From ") == 0 || strprefixcmp(line, ">From ") == 0)
 				continue;
+			had_first_line = 1;
 		}
 		if (!had_headers) {
 			/*

--- a/mail.c
+++ b/mail.c
@@ -356,6 +356,7 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 	int had_date = 0;
 	int had_last_line = 0;
 	int nocopy = 0;
+	int had_firstline = 0;
 
 	parse_state.state = NONE;
 
@@ -391,6 +392,11 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 			line[linelen + 1] = 0;
 			had_last_line = 1;
 		}
+		if (!had_firstline) {
+			had_firstline = 1;
+			if (strprefixcmp(line, "From ") == 0 || strprefixcmp(line, ">From ") == 0)
+				continue;
+		}
 		if (!had_headers) {
 			/*
 			 * Unless this is a continuation, switch of
@@ -399,9 +405,7 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 			if (!(line[0] == ' ' || line[0] == '\t'))
 				nocopy = 0;
 
-			if (strprefixcmp(line, "From ") == 0 || strprefixcmp(line, ">From ") == 0)
-				continue;
-			else if (strprefixcmp(line, "Date:") == 0)
+			if (strprefixcmp(line, "Date:") == 0)
 				had_date = 1;
 			else if (strprefixcmp(line, "Message-Id:") == 0)
 				had_messagid = 1;

--- a/mail.c
+++ b/mail.c
@@ -399,7 +399,9 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 			if (!(line[0] == ' ' || line[0] == '\t'))
 				nocopy = 0;
 
-			if (strprefixcmp(line, "Date:") == 0)
+			if (strprefixcmp(line, "From ") == 0 || strprefixcmp(line, ">From ") == 0)
+				continue;
+			else if (strprefixcmp(line, "Date:") == 0)
 				had_date = 1;
 			else if (strprefixcmp(line, "Message-Id:") == 0)
 				had_messagid = 1;


### PR DESCRIPTION
Add support for UUCP "From_ lines". RFC976 describes these as:

	... the "source path" (normally
	represented in one or more lines at the beginning of the message
	beginning either "From " or ">From ", sometimes called "From_
	lines".)

This fixes an issue where emails generated by cron would have their headers in the mailbody.
If the first line starts with "From " or ">From " the line is skipped instead of parsing everything as body.