### PR TITLE
Change RCPT TO to split up multiple addresses

### DIFF
--- a/net.c
+++ b/net.c
@@ -559,7 +559,12 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	READ_REMOTE_CHECK("MAIL FROM", 2);
 
 	/* XXX send ESMTP ORCPT */
-	addrtmp = strdup(it->addr);
+	if ((addrtmp = strdup(it->addr)) == NULL) {
+		syslog(LOG_CRIT, "remote delivery deffered: unable to allocate memory");
+		snprintf(errmsg, sizeof(errmsg), "unable to allocate memory");
+		error = 1;
+		goto out;
+	}
 	to_addr = strtok(addrtmp, ",");
 	while (to_addr != NULL) {
 		send_remote_command(fd, "RCPT TO:<%s>", to_addr);

--- a/net.c
+++ b/net.c
@@ -561,7 +561,6 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	/* XXX send ESMTP ORCPT */
 	if ((addrtmp = strdup(it->addr)) == NULL) {
 		syslog(LOG_CRIT, "remote delivery deffered: unable to allocate memory");
-		snprintf(errmsg, sizeof(errmsg), "unable to allocate memory");
 		error = 1;
 		goto out;
 	}

--- a/net.c
+++ b/net.c
@@ -465,7 +465,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
 	struct smtp_features features;
-	char line[1000], *to_addr, *addrtmp = NULL;
+	char line[1000], *addrtmp = NULL, *to_addr;
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 

--- a/net.c
+++ b/net.c
@@ -465,7 +465,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
 	struct smtp_features features;
-	char line[1000];
+	char line[1000], *to_addr;
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 
@@ -559,8 +559,12 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	READ_REMOTE_CHECK("MAIL FROM", 2);
 
 	/* XXX send ESMTP ORCPT */
-	send_remote_command(fd, "RCPT TO:<%s>", it->addr);
-	READ_REMOTE_CHECK("RCPT TO", 2);
+	to_addr = strtok(it->addr, ",");
+	while (to_addr != NULL) {
+		send_remote_command(fd, "RCPT TO:<%s>", to_addr);
+		READ_REMOTE_CHECK("RCPT TO", 2);
+		to_addr = strtok(NULL, ",");
+	}
 
 	send_remote_command(fd, "DATA");
 	READ_REMOTE_CHECK("DATA", 3);

--- a/net.c
+++ b/net.c
@@ -465,7 +465,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
 	struct smtp_features features;
-	char line[1000], *to_addr, *addrtmp;
+	char line[1000], *to_addr, *addrtmp = NULL;
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 
@@ -607,7 +607,8 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 		syslog(LOG_INFO, "remote delivery succeeded but QUIT failed: %s", neterr);
 out:
 
-	free(addrtmp);
+	if (addrtmp != NULL)
+		free(addrtmp);
 	close_connection(fd);
 	return (error);
 }

--- a/net.c
+++ b/net.c
@@ -607,8 +607,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 		syslog(LOG_INFO, "remote delivery succeeded but QUIT failed: %s", neterr);
 out:
 
-	if (addrtmp != NULL)
-		free(addrtmp);
+	free(addrtmp);
 	close_connection(fd);
 	return (error);
 }

--- a/net.c
+++ b/net.c
@@ -566,7 +566,6 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 		READ_REMOTE_CHECK("RCPT TO", 2);
 		to_addr = strtok(NULL, ",");
 	}
-	free(addrtmp);
 
 	send_remote_command(fd, "DATA");
 	READ_REMOTE_CHECK("DATA", 3);
@@ -608,6 +607,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 		syslog(LOG_INFO, "remote delivery succeeded but QUIT failed: %s", neterr);
 out:
 
+	free(addrtmp);
 	close_connection(fd);
 	return (error);
 }

--- a/net.c
+++ b/net.c
@@ -465,7 +465,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
 	struct smtp_features features;
-	char line[1000], *to_addr;
+	char line[1000], *to_addr, *addrtmp;
 	size_t linelen;
 	int fd, error = 0, do_auth = 0, res = 0;
 
@@ -559,12 +559,14 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	READ_REMOTE_CHECK("MAIL FROM", 2);
 
 	/* XXX send ESMTP ORCPT */
-	to_addr = strtok(it->addr, ",");
+	addrtmp = strdup(it->addr);
+	to_addr = strtok(addrtmp, ",");
 	while (to_addr != NULL) {
 		send_remote_command(fd, "RCPT TO:<%s>", to_addr);
 		READ_REMOTE_CHECK("RCPT TO", 2);
 		to_addr = strtok(NULL, ",");
 	}
+	free(addrtmp);
 
 	send_remote_command(fd, "DATA");
 	READ_REMOTE_CHECK("DATA", 3);

--- a/net.c
+++ b/net.c
@@ -560,7 +560,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 
 	/* XXX send ESMTP ORCPT */
 	if ((addrtmp = strdup(it->addr)) == NULL) {
-		syslog(LOG_CRIT, "remote delivery deffered: unable to allocate memory");
+		syslog(LOG_CRIT, "remote delivery deferred: unable to allocate memory");
 		error = 1;
 		goto out;
 	}


### PR DESCRIPTION
- RFC5321 section 4.1.1.3 states that RCPT TO only takes one address at a
  time.