### PR TITLE
Silence compiler warning for strncat.

### DIFF
--- a/net.c
+++ b/net.c
@@ -165,7 +165,8 @@ read_remote(int fd, int extbufsize, char *extbuf)
 			copysize = sizeof(neterr) - strlen(neterr) - 1;
 			if (copysize > len)
 				copysize = len;
-			strncat(neterr, buff, copysize);
+			strncat(neterr, buff, copysize - 1);
+				neterr[sizeof(neterr) - 1] = '\0';
 		}
 		/*
 		 * If there is an external buffer with a size bigger than zero


### PR DESCRIPTION
When compiling with newer GCC versions the following warning is emitted:

-----------------------------------------------------------------------
In file included from /usr/include/string.h:495,
                 from net.c:57:
In function ‘strncat’,
    inlined from ‘read_remote.part.0’ at net.c:168:4:
/usr/include/bits/string_fortified.h:136:10: warning: ‘__builtin___strncat_chk’ output \
 may be truncated copying between 0 and 1023 bytes from a string of length 2047 [-Wstringop-truncation]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

-----------------------------------------------------------------------

Similar reports can be found on the interwebs:

* Fix FTBFS with GCC-9 (Closes: #925677)
  https://salsa.debian.org/fcoe-team/fcoe-utils/-/blob/master/debian/patches/fix-gcc-warnings.patch

* gcc warns strncat() as terminating nul is not copied while it need not
  https://bugzilla.redhat.com/show_bug.cgi?id=1798636

This patch sheepishly attempts to follow these examples and the warning is now no
longer present. The program compiles but it may not be the right thing to do, please
verify!

 net.c | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)