### PR TITLE
Fixes in execl call and dma's own reallocf implementation

### DIFF
--- a/dfcompat.c
+++ b/dfcompat.c
@@ -96,7 +96,7 @@ reallocf(void *ptr, size_t size)
 	void *nptr;
 
 	nptr = realloc(ptr, size);
-	if (!nptr && ptr)
+	if (!nptr && ptr && size != 0)
 		free(ptr);
 	return (nptr);
 }

--- a/dma.c
+++ b/dma.c
@@ -422,6 +422,7 @@ main(int argc, char **argv)
 {
 	struct sigaction act;
 	char *sender = NULL;
+	char *own_name = NULL;
 	struct queue queue;
 	int i, ch;
 	int nodot = 0, showq = 0, queue_only = 0;
@@ -458,13 +459,15 @@ main(int argc, char **argv)
 	bzero(&queue, sizeof(queue));
 	LIST_INIT(&queue.queue);
 
-	if (strcmp(basename(argv[0]), "mailq") == 0) {
+	own_name = basename(argv[0]);
+
+	if (strcmp(own_name, "mailq") == 0) {
 		argv++; argc--;
 		showq = 1;
 		if (argc != 0)
 			errx(EX_USAGE, "invalid arguments");
 		goto skipopts;
-	} else if (strcmp(argv[0], "newaliases") == 0) {
+	} else if (strcmp(own_name, "newaliases") == 0) {
 		logident_base = "dma";
 		setlogident(NULL);
 
@@ -481,7 +484,7 @@ main(int argc, char **argv)
 			if (optarg[0] == 'c' || optarg[0] == 'm') {
 				break;
 			}
-			/* else FALLTRHOUGH */
+			/* Else FALLTHROUGH */
 		case 'b':
 			/* -bX is being ignored, except for -bp */
 			if (optarg[0] == 'p') {
@@ -491,7 +494,7 @@ main(int argc, char **argv)
 				queue_only = 1;
 				break;
 			}
-			/* else FALLTRHOUGH */
+			/* Else FALLTHROUGH */
 		case 'D':
 			daemonize = 0;
 			break;
@@ -511,7 +514,7 @@ main(int argc, char **argv)
 			/* -oX is being ignored, except for -oi */
 			if (optarg[0] != 'i')
 				break;
-			/* else FALLTRHOUGH */
+			/* Else FALLTHROUGH */
 		case 'O':
 			break;
 		case 'i':
@@ -545,7 +548,7 @@ main(int argc, char **argv)
 				doqueue = 1;
 				break;
 			}
-			/* FALLTHROUGH */
+			/* Else FALLTHROUGH */
 
 		default:
 			fprintf(stderr, "invalid argument: `-%c'\n", optopt);

--- a/dma.h
+++ b/dma.h
@@ -199,6 +199,7 @@ void parse_authfile(const char *);
 void hmac_md5(unsigned char *, int, unsigned char *, int, unsigned char *);
 int smtp_auth_md5(int, char *, char *);
 int smtp_init_crypto(int, int, struct smtp_features*);
+int verify_server_fingerprint(const X509 *);
 
 /* dns.c */
 int dns_get_mx_list(const char *, int, struct mx_hostentry **, int);

--- a/local.c
+++ b/local.c
@@ -82,7 +82,7 @@ create_mbox(const char *name)
 		for (i = 3; i <= maxfd; ++i)
 			close(i);
 
-		execl(LIBEXEC_PATH "/dma-mbox-create", "dma-mbox-create", name, NULL);
+		execl(LIBEXEC_PATH "/dma-mbox-create", "dma-mbox-create", name, (char *) NULL);
 		syslog(LOG_ERR, "cannot execute "LIBEXEC_PATH"/dma-mbox-create: %m");
 		exit(EX_SOFTWARE);
 

--- a/local.c
+++ b/local.c
@@ -82,7 +82,7 @@ create_mbox(const char *name)
 		for (i = 3; i <= maxfd; ++i)
 			close(i);
 
-		execl(LIBEXEC_PATH "/dma-mbox-create", "dma-mbox-create", name, (char *) NULL);
+		execl(LIBEXEC_PATH "/dma-mbox-create", "dma-mbox-create", name, (char *)NULL);
 		syslog(LOG_ERR, "cannot execute "LIBEXEC_PATH"/dma-mbox-create: %m");
 		exit(EX_SOFTWARE);
 

--- a/mail.c
+++ b/mail.c
@@ -200,6 +200,7 @@ again:
 				goto newaddr;
 			return (0);
 		}
+		/* fallthrough */
 
 	case QUIT:
 		return (0);


### PR DESCRIPTION
In order to avoid problems on architectures that do not define NULL as ((void *) 0), the last parameter to execl should be explicitly cast to (char *).
See also man execl(3).

Also prevent a double free() in own reallocf() implementation. See also [FreeBSD's reallocf implementation](https://github.com/freebsd/freebsd/blob/master/lib/libc/stdlib/reallocf.c).