### PR TITLE
Rewrite of configuration parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ dma-mbox-create
 aliases_parse.c
 aliases_parse.h
 aliases_scan.c
+auth_scan.c
+auth_parse.c
+auth_parse.h
+conf_parse.c
+conf_parse.h
+conf_scan.c

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ debversion=	$(shell ${SH} get-version.sh | sed -Ee 's/^v//;s/[.]([[:digit:]]+)[.
 CC?=		gcc
 CFLAGS?=	-O -pipe
 LDADD?=		-lssl -lcrypto -lresolv
+YACCFLAGS?=	-d
 
 CFLAGS+=	-Wall -Wno-format-truncation -DDMA_VERSION='"${version}"' -DLIBEXEC_PATH='"${LIBEXEC}"' -DCONF_PATH='"${CONFDIR}"'
 
@@ -39,13 +40,15 @@ LN?=		ln
 
 OBJS=	aliases_parse.o aliases_scan.o base64.o conf.o crypto.o
 OBJS+=	dma.o dns.o local.o mail.o net.o spool.o util.o
-OBJS+=	dfcompat.o
+OBJS+=	dfcompat.o conf_parse.o conf_scan.o auth_parse.o auth_scan.o
 
 all: dma dma-mbox-create
 
 clean:
 	-rm -f .depend dma dma-mbox-create *.[do]
 	-rm -f aliases_parse.[ch] aliases_scan.c
+	-rm -f auth_parse.[ch] auth_scan.c
+	-rm -f conf_parse.[ch] conf_scan.c
 
 install: all
 	${INSTALL} -d ${DESTDIR}${SBIN}
@@ -85,10 +88,22 @@ install-etc:
 	fi
 
 aliases_parse.c: aliases_parse.y
-	${YACC} -d -o aliases_parse.c aliases_parse.y
+	${YACC} ${YACCFLAGS} -o aliases_parse.c aliases_parse.y
 
 aliases_scan.c: aliases_scan.l
 	${LEX} -t aliases_scan.l > aliases_scan.c
+	
+auth_parse.c: auth_parse.y
+	${YACC} ${YACCFLAGS} -p auth_ -b auth_ -o auth_parse.c auth_parse.y
+	
+auth_scan.c: auth_scan.l
+	${LEX} -t auth_scan.l > auth_scan.c
+
+conf_parse.c: conf_parse.y
+	${YACC} ${YACCFLAGS} -p conf_ -b conf_ -o conf_parse.c conf_parse.y
+
+conf_scan.c: conf_scan.l
+	${LEX} -t conf_scan.l > conf_scan.c
 
 .SUFFIXES: .c .o
 

--- a/aliases_scan.l
+++ b/aliases_scan.l
@@ -13,12 +13,13 @@
 
 %%
 
-[^:,#[:space:][:cntrl:]]+	{yylval.ident = strdup(yytext); return T_IDENT;}
-^([[:blank:]]*(#.*)?\n)+	;/* ignore empty lines */
-[:,\n]				return yytext[0];
-(\n?[[:blank:]]+|#.*)+		;/* ignore whitespace and continuation */
-\\\n				;/* ignore continuation.  not allowed in comments */
-.				return T_ERROR;
-<<EOF>>				return T_EOF;
+[^:,#[:space:][:cntrl:]]+       {yylval.ident = strdup(yytext); return T_IDENT;}
+^([[:blank:]]*(#.*)?\n)+        ;/* ignore empty lines */
+[:,\n]                          return yytext[0];
+(\n?[[:blank:]]+|#.*)+          ;/* ignore whitespace and continuation */
+\\\n                            ;/* ignore continuation.  not allowed in comments */
+.                               return T_ERROR;
+<<EOF>>                         return T_EOF;
 
 %%
+

--- a/auth_parse.y
+++ b/auth_parse.y
@@ -8,11 +8,11 @@ int auth_error(const char *);
 
 int auth_error(const char *s)
 {
-	extern char *auth_text;
-	
-	fprintf(stderr, "error parsing %s at symbol: \"%s\" on line %d\n", s, auth_text, auth_lineno);
-	
-	return 0;
+        extern char *auth_text;
+        
+        fprintf(stderr, "error parsing %s at symbol: \"%s\" on line %d\n", s, auth_text, auth_lineno);
+        
+        return 0;
 }
 %}
 
@@ -36,22 +36,22 @@ int auth_error(const char *s)
 %%
 
 auth_file: /* empty */
-	| auth_file auth_setting
+        | auth_file auth_setting
 	
 auth_setting: user T_PIPE host T_COLON password
-	{
-		if(add_auth_entry($1, $3, $5) != 0)
-		{
-			fprintf(stderr, "Error adding authentication information to list.\n");
-			free($1);
-			free($3);
-			free($5);
-			YYABORT;
-		}
-	}
+        {
+                if(add_auth_entry($1, $3, $5) != 0) {
+                        fprintf(stderr, "Error adding authentication information to list.\n");
+                        free($1);
+                        free($3);
+                        free($5);
+                        YYABORT;
+                }
+        }
 
-user:		T_USERNAME
-host: 		T_HOSTNAME
-password:	T_PASSWORD
+user:           T_USERNAME
+host:           T_HOSTNAME
+password:       T_PASSWORD
 
 %%
+

--- a/auth_parse.y
+++ b/auth_parse.y
@@ -1,0 +1,57 @@
+%{
+#include <stdio.h>
+#include "dma.h"
+
+int auth_lex(void);
+extern int auth_lineno;
+int auth_error(const char *);
+
+int auth_error(const char *s)
+{
+	extern char *auth_text;
+	
+	fprintf(stderr, "error parsing %s at symbol: \"%s\" on line %d\n", s, auth_text, auth_lineno);
+	
+	return 0;
+}
+%}
+
+%union
+{
+	char *str_type;
+}
+
+/* declare tokens */
+%token <str_type> T_USERNAME
+%token <str_type> T_HOSTNAME
+%token <str_type> T_PASSWORD
+%token T_PIPE
+%token T_COLON
+%token T_ERROR
+
+%type <str_type> user
+%type <str_type> host
+%type <str_type> password
+
+%%
+
+auth_file: /* empty */
+	| auth_file auth_setting
+	
+auth_setting: user T_PIPE host T_COLON password
+	{
+		if(add_auth_entry($1, $3, $5) != 0)
+		{
+			fprintf(stderr, "Error adding authentication information to list.\n");
+			free($1);
+			free($3);
+			free($5);
+			YYABORT;
+		}
+	}
+
+user:		T_USERNAME
+host: 		T_HOSTNAME
+password:	T_PASSWORD
+
+%%

--- a/auth_scan.l
+++ b/auth_scan.l
@@ -40,3 +40,4 @@ BLANKS			[[:blank:]]+
 <*>.									{ return T_ERROR; }
 
 %%
+

--- a/auth_scan.l
+++ b/auth_scan.l
@@ -10,8 +10,10 @@
 %option prefix="auth_"
 %option noyywrap
 %x pass_t
+%x host_t
 
-USER	   		[^[:space:][:cntrl:]\|:\.]+
+
+USER	   		[^[:space:][:cntrl:]\|:]+
 HOSTNAME		[[:alnum:]][[:alnum:]\.\-]*[[:alnum:]]+
 PASSWORD		[^[:cntrl:]]+$
 BLANKS			[[:blank:]]+
@@ -19,20 +21,20 @@ BLANKS			[[:blank:]]+
 %%
 
 {USER}									{ auth_lval.str_type = strdup(yytext); return T_USERNAME; }
-{HOSTNAME}								{ auth_lval.str_type = strdup(yytext); return T_HOSTNAME; }
-\|										{ return T_PIPE; }
+\|										{ BEGIN(host_t); return T_PIPE; }
+<host_t>{HOSTNAME}						{ BEGIN(INITIAL); auth_lval.str_type = strdup(yytext); return T_HOSTNAME; }
 :										{ BEGIN(pass_t); return T_COLON; }
 <pass_t>{PASSWORD}						{ auth_lval.str_type = strdup(yytext); BEGIN(INITIAL); return T_PASSWORD; }
 
 
 
-{BLANKS}								; /* Blanks are silently ignored when not 
-										   * parsing the password as passwords
-										   * may contain spaces as well */
-
 ^(\r?\n?[[:blank:]]*(#.*)?)+			;  /*  ignore lines that are empty from the beginning
 													*(and optionally comments without anything
 													* but spaces before) */
+													
+<*>{BLANKS}								; /* Blanks are silently ignored. Passwords
+										   * may contain spaces though */
+
 \r?\n									;
 
 <*>.									{ return T_ERROR; }

--- a/auth_scan.l
+++ b/auth_scan.l
@@ -1,0 +1,40 @@
+%{
+
+#include <string.h>
+#include "auth_parse.h"
+
+%}
+
+%option yylineno
+%option noinput nounput
+%option prefix="auth_"
+%option noyywrap
+%x pass_t
+
+USER	   		[^[:space:][:cntrl:]\|:\.]+
+HOSTNAME		[[:alnum:]][[:alnum:]\.\-]*[[:alnum:]]+
+PASSWORD		[^[:cntrl:]]+$
+BLANKS			[[:blank:]]+
+
+%%
+
+{USER}									{ auth_lval.str_type = strdup(yytext); return T_USERNAME; }
+{HOSTNAME}								{ auth_lval.str_type = strdup(yytext); return T_HOSTNAME; }
+\|										{ return T_PIPE; }
+:										{ BEGIN(pass_t); return T_COLON; }
+<pass_t>{PASSWORD}						{ auth_lval.str_type = strdup(yytext); BEGIN(INITIAL); return T_PASSWORD; }
+
+
+
+{BLANKS}								; /* Blanks are silently ignored when not 
+										   * parsing the password as passwords
+										   * may contain spaces as well */
+
+^(\r?\n?[[:blank:]]*(#.*)?)+			;  /*  ignore lines that are empty from the beginning
+													*(and optionally comments without anything
+													* but spaces before) */
+\r?\n									;
+
+<*>.									{ return T_ERROR; }
+
+%%

--- a/bsd/dma/Makefile
+++ b/bsd/dma/Makefile
@@ -72,3 +72,4 @@ install:
 	install  -o root -g wheel -m 444 dma.8.gz  /usr/share/man/man8/
 
 .include <bsd.prog.mk>
+

--- a/bsd/dma/Makefile
+++ b/bsd/dma/Makefile
@@ -11,19 +11,64 @@ CFLAGS+= -DCONF_PATH='"${CONFDIR}"'
 DPADD=  ${LIBSSL} ${LIBCRYPTO}
 LDADD=  -lssl -lcrypto
 
-PROG=	dma
+YACCFLAGS+=	-d
+
 .PATH: ${.CURDIR}/../..
-SRCS=	aliases_parse.y aliases_scan.l base64.c conf.c crypto.c
-SRCS+=	dma.c dns.c local.c mail.c net.c spool.c util.c
-MAN=	dma.8
+PATHTOYACCFILES=${.CURDIR}/../..
+MAN=    dma.8
 
-PREFIX?=	/usr/local
-LIBEXEC?=	${PREFIX}/libexec
-CONFDIR?=	${PREFIX}/etc/dma
+PREFIX?=        /usr/local
+LIBEXEC?=       ${PREFIX}/libexec
+CONFDIR?=       ${PREFIX}/etc/dma
 
+YACC?=		yacc
+LEX?=		lex
+
+OBJS=   aliases_parse.o aliases_scan.o base64.o conf.o crypto.o
+OBJS+=  dma.o dns.o local.o mail.o net.o spool.o util.o
+OBJS+=  conf_parse.o conf_scan.o auth_parse.o auth_scan.o
+
+all:	dma
+
+aliases_parse.c: aliases_parse.y
+	${YACC} ${YACCFLAGS} -o aliases_parse.c ${PATHTOYACCFILES}/aliases_parse.y
+
+aliases_scan.c: aliases_scan.l
+	${LEX} -t ${PATHTOYACCFILES}/aliases_scan.l > aliases_scan.c
+
+auth_parse.c: auth_parse.y
+	${YACC} ${YACCFLAGS} -p auth_ -b auth_ -o auth_parse.c ${PATHTOYACCFILES}/auth_parse.y
+
+auth_scan.c: auth_scan.l
+	${LEX} -t ${PATHTOYACCFILES}/auth_scan.l > auth_scan.c
+
+conf_parse.c: conf_parse.y
+	${YACC} ${YACCFLAGS} -p conf_ -b conf_ -o conf_parse.c ${PATHTOYACCFILES}/conf_parse.y
+
+conf_scan.c: conf_scan.l
+	${LEX} -t ${PATHTOYACCFILES}/conf_scan.l > conf_scan.c
+
+.SUFFIXES: .c .o
+
+.c.o:
+	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ -c $<
+
+dma:	${OBJS}
+	${CC} ${LDFLAGS} -o $@ ${OBJS} ${LDADD}
+	
+clean:
+	-rm -f .depend dma dma-mbox-create *.[do]
+	-rm -f aliases_parse.[ch] aliases_scan.c
+	-rm -f auth_parse.[ch] auth_scan.c
+	-rm -f conf_parse.[ch] conf_scan.c
+	
 BINOWN= root
 BINGRP= mail
 BINMODE=2555
-WARNS?=	5
+WARNS?= 5
+
+install:
+	install  -s -o ${BINOWN} -g ${BINGRP} -m ${BINMODE}   dma ${LIBEXEC}
+	install  -o root -g wheel -m 444 dma.8.gz  /usr/share/man/man8/
 
 .include <bsd.prog.mk>

--- a/conf.c
+++ b/conf.c
@@ -72,14 +72,14 @@ SLIST_HEAD( authusers, authuser);
 
 /* Initializations */
 
-struct S_CONFIGHEAD config_head = SLIST_HEAD_INITIALIZER(config_head);
-struct authusers authusers = LIST_HEAD_INITIALIZER(authusers);
-bool is_configuration_initialized = false;
+static struct S_CONFIGHEAD config_head = SLIST_HEAD_INITIALIZER(config_head);
+static struct authusers authusers = LIST_HEAD_INITIALIZER(authusers);
+static bool is_configuration_initialized = false;
 
-struct config_item_t *last_checked_item = NULL;
+static struct config_item_t *last_checked_item = NULL;
 
-/* Static function declarations
- * they are "private" (internal linkage) */
+
+ /* Static function declarations */
 
 static int check_fingerprint_configuration(const char*, const char*);
 static int check_nullclient_configuration(const char*, const char*);
@@ -152,13 +152,14 @@ parse_authfile(const char *path)
          * the checks are not passed, but emit an informational warning message.
          */
         if(fstat(fileno(auth_in), &statbuffer) == 0) {
-                /* Check file permissions
+                /* 
+                 * Check file permissions
                  * we only care about the world permissions
                  */
                 if((statbuffer.st_mode & S_IRWXO) != 0)
-                        log_warning("Auth file '%s': File permissions are %o whereas 640 is recommended. "
+                        log_warning("Auth file '%s': File permissions are %lo whereas 640 is recommended. "
                                         "Thus, your passwords may be readable by others.",
-                                        path, statbuffer.st_mode & 0777);
+                                        path, (unsigned long)(statbuffer.st_mode & 0777));
                 group = getgrnam(DMA_GROUP);
 
                 if(group != NULL) {
@@ -484,9 +485,11 @@ is_configuration_setting_enabled(const char *identifier)
                         if (!item->boolean_flag) {
                                 if (item->str_value != NULL) {
                                         last_checked_item = item;
-                                        /* Pointer to the last item that was queried
+                                        /*
+                                         * Pointer to the last item that was queried
                                          * this is subsequently checked first,
-                                         * if get_configuration_value() is called */
+                                         * if get_configuration_value() is called
+                                         */
                                         return (true);
                                 } else {
                                         return (false);
@@ -508,8 +511,10 @@ is_configuration_setting_enabled(const char *identifier)
 const char*
 get_configuration_value(const char *identifier)
 {
-        /* If isConfigurationFlagEnabled() has been called before,
-         * we'll try to use the item found there first */
+        /*
+         * If isConfigurationFlagEnabled() has been called before,
+         * we'll try to use the item found there first
+         */
         struct config_item_t *item = NULL;
         char *str_value = NULL;
 
@@ -636,7 +641,8 @@ print_masquerade_settings(void)
 }
 #endif
 
-/* Check function for the MAILNAME setting
+/* 
+ * Check function for the MAILNAME setting
  * this function only returns non-zero in the case of a probable data corruption
  * All other checks can only lead to warning messages,
  * as an invalid MAILNAME configuration does not prevent local mails from working properly
@@ -667,8 +673,10 @@ check_mailname_configuration(const char *identifier, const char *value)
                         else
                                 log_warning("Warning: Invalid character '%c' in hostname: '%s'", buffer[counter], buffer);
 
-                        break; /* No matter if the char is invalid or just a newline:
-                                * We're done here */
+                        break; /* 
+                                * No matter if the char is invalid or just a newline:
+                                * We're done here
+                                */
                 }
         }
 

--- a/conf.c
+++ b/conf.c
@@ -48,23 +48,23 @@
 
 /* Declarations of "private" types */
 
-typedef int (*check_ptr_t)(const char *, const char *);
+typedef int (*check_ptr_t)(const char*, const char*);
 struct config_item_t {
-	check_ptr_t checkFunction;
-	char *identifier;
-	char *str_value;
-	bool needs_value;
-	SLIST_ENTRY(config_item_t) next_item;
+        check_ptr_t checkFunction;
+        char *identifier;
+        char *str_value;
+        bool boolean_flag;
+        SLIST_ENTRY(config_item_t) next_item;
 };
-SLIST_HEAD(S_CONFIGHEAD, config_item_t);
+SLIST_HEAD( S_CONFIGHEAD, config_item_t);
 
 struct authuser {
-	SLIST_ENTRY(authuser) next;
-	char *login;
-	char *password;
-	char *host;
+        SLIST_ENTRY(authuser) next;
+        char *login;
+        char *password;
+        char *host;
 };
-SLIST_HEAD(authusers, authuser);
+SLIST_HEAD( authusers, authuser);
 
 /* Initializations */
 
@@ -77,9 +77,10 @@ struct config_item_t *last_checked_item = NULL;
 /* Static function declarations
  * they are "private" (internal linkage) */
 
-static int check_fingerprint_configuration(const char *, const char *);
-static int check_nullclient_configuration(const char *, const char *);
-static void initialize_configuration_setting(const char*, check_ptr_t, bool, const char*);
+static int check_fingerprint_configuration(const char*, const char*);
+static int check_nullclient_configuration(const char*, const char*);
+static void initialize_configuration_setting(const char*, check_ptr_t, bool,
+                                             const char*);
 
 /* Debug Configuration */
 
@@ -91,31 +92,28 @@ static void print_auth_items(void);
 static void print_masquerade_settings(void);
 #endif
 
-
 /*
  * Remove trailing \n's
  */
-void
-trim_line(char *line)
+void trim_line(char *line)
 {
-	size_t linelen;
-	char *p;
+        size_t linelen;
+        char *p;
 
-	if ((p = strchr(line, '\n')))
-		*p = (char)0;
+        if ((p = strchr(line, '\n')))
+                *p = (char) 0;
 
-	/* Escape leading dot in every case */
-	linelen = strlen(line);
-	if (line[0] == '.') {
-		if ((linelen + 2) > 1000) {
-			syslog(LOG_CRIT, "Cannot escape leading dot.  Buffer overflow");
-			exit(EX_DATAERR);
-		}
-		memmove((line + 1), line, (linelen + 1));
-		line[0] = '.';
-	}
+        /* Escape leading dot in every case */
+        linelen = strlen(line);
+        if (line[0] == '.') {
+                if ((linelen + 2) > 1000) {
+                        syslog(LOG_CRIT, "Cannot escape leading dot.  Buffer overflow");
+                        exit(EX_DATAERR);
+                }
+                memmove((line + 1), line, (linelen + 1));
+                line[0] = '.';
+        }
 }
-
 
 /*
  * Read the SMTP authentication config file
@@ -125,485 +123,432 @@ trim_line(char *line)
  *
  * A line starting with # is treated as comment and ignored.
  */
-void
-parse_authfile(const char *path)
+void parse_authfile(const char *path)
 {
-	auth_in = fopen(path, "r");
-	if (auth_in == NULL) {
-		errlog(EX_NOINPUT, "can not open auth file `%s'", path);
-		/* NOTREACHED */
-	}
+        auth_in = fopen(path, "r");
+        if (auth_in == NULL) {
+                errlog(EX_NOINPUT, "can not open auth file `%s'", path);
+                /* NOTREACHED */
+        }
 
-	if(auth_parse())
-		errlog(EX_CONFIG, "syntax error in authfile '%s'", path);
-	fclose(auth_in);
+        if (auth_parse())
+                errlog(EX_CONFIG, "syntax error in authfile '%s'", path);
+        fclose(auth_in);
 
 #ifdef DEBUG_CONF
-	print_auth_items();
+        print_auth_items();
 #endif
 }
 
-void
-parse_conf(const char *config_path)
+void parse_conf(const char *config_path)
 {
-	if(is_configuration_initialized == false)
-		errlogx(EX_SOFTWARE, "parse_conf must be run after initialize_all_configuration_settings()");
+        if (!is_configuration_initialized)
+                errlogx(EX_SOFTWARE,
+                                "parse_conf must be run after initialize_all_configuration_settings()");
 
-	conf_in = fopen(config_path, "r");
-	if (conf_in == NULL) {
-		/* Don't treat a non-existing config file as error */
-		if (errno == ENOENT)
-			return;
-		errlog(EX_NOINPUT, "can not open config `%s'", config_path);
-		/* NOTREACHED */
-	}
-	if(conf_parse())
-		errlogx(EX_CONFIG, "Syntax error in config file '%s'", config_path);
+        conf_in = fopen(config_path, "r");
+        if (conf_in == NULL) {
+                /* Don't treat a non-existing config file as error */
+                if (errno == ENOENT)
+                        return;
+                errlog(EX_NOINPUT, "can not open config `%s'", config_path);
+                /* NOTREACHED */
+        }
+        if (conf_parse())
+                errlogx(EX_CONFIG, "Syntax error in config file '%s'", config_path);
 
-	fclose(conf_in);
+        fclose(conf_in);
 
-	/* NULLCLIENT configuration can only be checked once all config entries have been parsed */
-	if(is_configuration_setting_enabled(CONF_NULLCLIENT))
-		if(check_nullclient_configuration(CONF_NULLCLIENT, NULL) != 0)
-			errlogx(EX_CONFIG, "%s: NULLCLIENT requires SMARTHOST", config_path);
+        /* NULLCLIENT configuration can only be checked once all config entries have been parsed */
+        if (is_configuration_setting_enabled(CONF_NULLCLIENT))
+                if (check_nullclient_configuration(CONF_NULLCLIENT, NULL) != 0)
+                        errlogx(EX_CONFIG, "%s: NULLCLIENT requires SMARTHOST",
+                                        config_path);
 
 #ifdef DEBUG_CONF
-	print_configuration_settings();
-	print_masquerade_settings();
+        print_configuration_settings();
+        print_masquerade_settings();
 #endif
 }
 
 void initialize_all_configuration_settings(void)
 {
-	if(is_configuration_initialized != false)
-		/* This function shall only run once... */
-		return;
+        if (is_configuration_initialized)
+                /* This function shall only run once... */
+                return;
 
-	is_configuration_initialized = true;
+        is_configuration_initialized = true;
 
-	SLIST_INIT(&config_head);
+        SLIST_INIT(&config_head);
 
-	/* SMARTHOST */
-	initialize_configuration_setting(CONF_SMARTHOST, NULL, true, NULL);
-	/* PORT */
-	initialize_configuration_setting(CONF_PORT, NULL, true, SMTP_PORT_STRING);
-	/* and so on */
-	initialize_configuration_setting(CONF_ALIASES, NULL, true, DEFAULT_ALIASES_PATH);
-	initialize_configuration_setting(CONF_SPOOLDIR, NULL, true, DEFAULT_SPOOLDIR);
-	initialize_configuration_setting(CONF_AUTHPATH, NULL, true, NULL);
-	initialize_configuration_setting(CONF_CERTFILE, NULL, true, NULL);
-	initialize_configuration_setting(CONF_MAILNAME, NULL, true,  NULL);
-	initialize_configuration_setting(CONF_MASQUERADE, NULL, true, NULL);
-	initialize_configuration_setting(CONF_STARTTLS, NULL, false, NULL);
-	initialize_configuration_setting(CONF_FINGERPRINT, &check_fingerprint_configuration, true, NULL);
-	initialize_configuration_setting(CONF_TLS_OPP, NULL, false, NULL);
-	initialize_configuration_setting(CONF_SECURETRANSFER, NULL, false, NULL);
-	initialize_configuration_setting(CONF_DEFER, NULL, false, NULL);
-	initialize_configuration_setting(CONF_INSECURE, NULL, false, NULL);
-	initialize_configuration_setting(CONF_FULLBOUNCE, NULL, false, NULL);
-	initialize_configuration_setting(CONF_NULLCLIENT, NULL, false, NULL);
+        /* SMARTHOST */
+        initialize_configuration_setting(CONF_SMARTHOST, NULL, false, NULL);
+        /* PORT */
+        initialize_configuration_setting(CONF_PORT, NULL, false, SMTP_PORT_STRING);
+        /* and so on */
+        initialize_configuration_setting(CONF_ALIASES, NULL, false,
+                                         DEFAULT_ALIASES_PATH);
+        initialize_configuration_setting(CONF_SPOOLDIR, NULL, false, DEFAULT_SPOOLDIR);
+        initialize_configuration_setting(CONF_AUTHPATH, NULL, false, NULL);
+        initialize_configuration_setting(CONF_CERTFILE, NULL, false, NULL);
+        initialize_configuration_setting(CONF_MAILNAME, NULL, false, NULL);
+        initialize_configuration_setting(CONF_MASQUERADE, NULL, false, NULL);
+        initialize_configuration_setting(CONF_STARTTLS, NULL, true, NULL);
+        initialize_configuration_setting(CONF_FINGERPRINT,
+                                         &check_fingerprint_configuration, false, NULL);
+        initialize_configuration_setting(CONF_TLS_OPP, NULL, true, NULL);
+        initialize_configuration_setting(CONF_SECURETRANSFER, NULL, true, NULL);
+        initialize_configuration_setting(CONF_DEFER, NULL, true, NULL);
+        initialize_configuration_setting(CONF_INSECURE, NULL, true, NULL);
+        initialize_configuration_setting(CONF_FULLBOUNCE, NULL, true, NULL);
+        initialize_configuration_setting(CONF_NULLCLIENT, NULL, true, NULL);
 }
 
-static void initialize_configuration_setting(
-		const char* identifier,
-		check_ptr_t func_ptr, bool needs_value,
-		const char* default_value
-		)
+static void initialize_configuration_setting(const char *identifier,
+                                             check_ptr_t func_ptr,
+                                             bool is_boolean_flag,
+                                             const char *default_value)
 {
-	struct config_item_t *item;
+        struct config_item_t *item;
 
-	if(identifier == NULL)
-		return;
+        if (identifier == NULL)
+                return;
 
-	/* Check if the setting has already been initialized */
-	SLIST_FOREACH(item, &config_head, next_item)
-		if(!strcmp(identifier, item->identifier))
-			/* Already in list */
-			errlogx(EX_SOFTWARE, "Trying to initialize setting '%s' more than once", identifier);
+        /* Check if the setting has already been initialized */
+        SLIST_FOREACH(item, &config_head, next_item)
+                if (!strcmp(identifier, item->identifier))
+                        /* Already in list */
+                        errlogx(EX_SOFTWARE, "Trying to initialize setting '%s' more than once",
+                                        identifier);
 
-	item = calloc(1, sizeof(struct config_item_t));
-	if(item == NULL)
-		errlog(EX_OSERR,"Error allocating memory\n");
-		/* exit */
+        item = calloc(1, sizeof(struct config_item_t));
+        if (item == NULL)
+                errlog(EX_OSERR, "Error allocating memory\n");
+        /* exit */
 
-	/* We use strdup() here so that we'll be able to properly clean up everything */
-	item->identifier = strdup(identifier);
-	item->checkFunction = func_ptr;
-	item->needs_value = needs_value;
+        /* We use strdup() here so that we'll be able to properly clean up everything */
+        item->identifier = strdup(identifier);
+        item->checkFunction = func_ptr;
+        item->boolean_flag = is_boolean_flag;
 
-	if(default_value != NULL)
-		item->str_value = strdup(default_value);
-	else
-		item->str_value = NULL;
+        if (default_value != NULL)
+                item->str_value = strdup(default_value);
+        else
+                item->str_value = NULL;
 
-	SLIST_INSERT_HEAD(&config_head, item, next_item);
+        SLIST_INSERT_HEAD(&config_head, item, next_item);
 }
 
 int try_to_set_configuration_setting(char *identifier, char *value)
 {
-	struct config_item_t *item = NULL;
-	bool found = false;
+        struct config_item_t *item = NULL;
+        bool found = false;
 
-	SLIST_FOREACH(item, &config_head, next_item)
-		if(!strcmp(identifier, item->identifier))
-		{
-			found = true;
-			break;
-		}
+        SLIST_FOREACH(item, &config_head, next_item)
+                if (!strcmp(identifier, item->identifier)) {
+                        found = true;
+                        break;
+                }
 
-	if(found)		/* item is pointing to the correct item now */
-	{
-		 /* Let's see if it requires a value */
-		if(item->needs_value)
-		{
-			/* Check values */
-			if(value == NULL)
-				/* Item requires a value, but no value has been provided! */
-				return EX_CONFIG;
+        if (found) {
+                /* item is pointing to the correct item now */
+                /* Let's see if it requires a value */
+                if (!item->boolean_flag) {
+                        /* Check values */
+                        if (value == NULL)
+                                /* Item requires a value, but no value has been provided! */
+                                return EX_CONFIG;
 
-			/* Call the check function, if it exists */
-			if(item->checkFunction != NULL)
-				if(item->checkFunction(identifier, value) != 0)
-					return EX_CONFIG;
+                        /* Call the check function, if it exists */
+                        if (item->checkFunction != NULL)
+                                if (item->checkFunction(identifier, value) != 0)
+                                        return EX_CONFIG;
 
-			/* Else let's store the value and return */
-			if(item->str_value != NULL)
-				free(item->str_value);	/* Let's free the old value first */
+                        /* Else let's store the value and return */
+                        if (item->str_value != NULL)
+                                free(item->str_value); /* Let's free the old value first */
 
-			item->str_value = value;
-			return 0;
-		}
-		else	/* No value needed */
-		{
-			/* Check if a value has been provided even though no value is expected */
-			if(value != NULL)
-				return EX_CONFIG;
+                        item->str_value = value;
+                        return 0;
+                } else {
+                        /* No value needed */
+                        /* Check if a value has been provided even though no value is expected */
+                        if (value != NULL)
+                                return EX_CONFIG;
 
-			if(item->checkFunction != NULL)
-				if(item->checkFunction(identifier, value) != 0)
-					return EX_CONFIG;
+                        if (item->checkFunction != NULL)
+                                if (item->checkFunction(identifier, value) != 0)
+                                        return EX_CONFIG;
 
-			/* else let's set the config flag to on
-			 * we do not bother changing the value if it is already set,
-			 * as its concrete value is meaningless.
-			 * The value can already be set,
-			 * if its flag has been enabled more than once in the config file. */
-			if(item->str_value == NULL)
-				item->str_value = strdup("ON");
-			return 0;
-		}
-	}
-	else /* Item has not been found */
-		return EX_CONFIG;
+                        /* else let's set the config flag to on
+                         * we do not bother changing the value if it is already set,
+                         * as its concrete value is meaningless.
+                         * The value can already be set,
+                         * if its flag has been enabled more than once in the config file. */
+                        if (item->str_value == NULL)
+                                item->str_value = strdup("ON");
+                        return 0;
+                }
+        } else {
+                /* Item has not been found */
+                return EX_CONFIG;
+        }
 }
 
-void free_all_configuration_settings(void)
+static int check_fingerprint_configuration(const char *identifier,
+                                           const char *value)
 {
-	struct config_item_t* current_item;
-	struct config_item_t* next_item;
+        unsigned int counter;
+        unsigned char *fingerprint;
 
-	last_checked_item = NULL;
+        if (identifier == NULL || value == NULL)
+                return EX_CONFIG;
 
-	current_item = SLIST_FIRST(&config_head);
-	while (current_item != NULL)
-	{
-		next_item = SLIST_NEXT(current_item, next_item);
+        if (strlen(value) != SHA256_DIGEST_LENGTH * 2)
+                return EX_CONFIG;
 
-		if(current_item->identifier != NULL)
-			free(current_item->identifier);
-		if(current_item->str_value != NULL)
-			free(current_item->str_value);
+        fingerprint = malloc(SHA256_DIGEST_LENGTH);
+        if (fingerprint == NULL)
+                return EX_OSERR;
 
-		free(current_item);
-		current_item = next_item;
-	}
-	SLIST_INIT(&config_head);
-}
+        for (counter = 0; counter < SHA256_DIGEST_LENGTH; counter++)
+                if (sscanf(value + 2 * counter, "%02hhx", &fingerprint[counter]) != 1) {
+                        free(fingerprint);
+                        return EX_CONFIG;
+                }
 
-static int check_fingerprint_configuration(const char *identifier, const char *value)
-{
-	unsigned int counter;
-	unsigned char *fingerprint;
-
-	if(identifier == NULL || value == NULL)
-		return EX_CONFIG;
-
-	if(strlen(value) != SHA256_DIGEST_LENGTH * 2)
-		return EX_CONFIG;
-
-	fingerprint = malloc(SHA256_DIGEST_LENGTH);
-	if (fingerprint == NULL)
-		return EX_OSERR;
-
-	for (counter = 0; counter < SHA256_DIGEST_LENGTH; counter++)
-		if(sscanf(value + 2 * counter, "%02hhx", &fingerprint[counter]) != 1)
-		{
-			free(fingerprint);
-			return EX_CONFIG;
-		}
-
-	free(fingerprint);
-	return 0;
+        free(fingerprint);
+        return 0;
 }
 
 /* Helper function to return the masquerade settings split up in login and host */
-struct masquerade_config_t *extract_masquerade_settings(const char *value)
+struct masquerade_config_t* extract_masquerade_settings(const char *value)
 {
-	char *user;
-	char *host;
-	char *copy_of_value;
+        char *user;
+        char *host;
+        char *copy_of_value;
 
-	struct masquerade_config_t *masquerade;
-
-#ifdef DEBUG_CONF
-	printf("extract_masquerade_settings called with value '%s'\n", value);
-#endif
-	copy_of_value = host = user = NULL;
-
-	if(value == NULL)
-		return NULL;
-
-	masquerade = malloc(sizeof(struct masquerade_config_t));
-
-	copy_of_value = strdup(value);
-
-	if(masquerade == NULL || copy_of_value == NULL)
-		return NULL;
-
-	host = strrchr(copy_of_value, '@');
-	if(host != NULL)
-	{
-		*host = '\0';
-		host++;
-		user = copy_of_value;
-	}
-	else
-		host = copy_of_value;
-
-	if(host != NULL && *host == '\0')
-		host = NULL;
-	if(user != NULL && *user == '\0')
-		user = NULL;
-
-	if(host != NULL)
-		masquerade->host = strdup(host);
-	else
-		masquerade->host = NULL;
-
-	if(user != NULL)
-		masquerade->user = strdup(user);
-	else
-		masquerade->user = NULL;
+        struct masquerade_config_t *masquerade;
 
 #ifdef DEBUG_CONF
-	printf("masquerade_config.host: '%s'\tmasquerade_config.user: '%s'\n", masquerade->host, masquerade->user);
+        printf("extract_masquerade_settings called with value '%s'\n", value);
+#endif
+        copy_of_value = host = user = NULL;
+
+        if (value == NULL)
+                return NULL;
+
+        masquerade = malloc(sizeof(struct masquerade_config_t));
+
+        if (masquerade == NULL)
+                return NULL;
+
+        copy_of_value = strdup(value);
+
+        if (copy_of_value == NULL) {
+                free(masquerade);
+                return NULL;
+        }
+
+        host = strrchr(copy_of_value, '@');
+        if (host != NULL) {
+                *host = '\0';
+                host++;
+                user = copy_of_value;
+        } else {
+                host = copy_of_value;
+        }
+
+        if (host != NULL && *host == '\0')
+                host = NULL;
+        if (user != NULL && *user == '\0')
+                user = NULL;
+
+        if (host != NULL)
+                masquerade->host = strdup(host);
+        else
+                masquerade->host = NULL;
+
+        if (user != NULL)
+                masquerade->user = strdup(user);
+        else
+                masquerade->user = NULL;
+
+#ifdef DEBUG_CONF
+        printf("masquerade_config.host: '%s'\tmasquerade_config.user: '%s'\n",
+                        masquerade->host, masquerade->user);
 #endif
 
-	free(copy_of_value);
-	return masquerade;;
+        free(copy_of_value);
+        return masquerade;
 }
 
-static int check_nullclient_configuration(const char *identifier, const char *value)
+static int check_nullclient_configuration(const char *identifier,
+                                          const char *value)
 {
-	if(identifier == NULL || value != NULL)
-		errlogx(EX_SOFTWARE, "checkNullClientConfiguration called with invalid arguments.");
+        if (identifier == NULL || value != NULL)
+                errlogx(EX_SOFTWARE,
+                                "checkNullClientConfiguration called with invalid arguments.");
 
-	if(is_configuration_setting_enabled(CONF_SMARTHOST))
-		return 0;
+        if (is_configuration_setting_enabled(CONF_SMARTHOST))
+                return 0;
 
-	/* NULLCLIENT requires SMARTHOST */
-	return EX_CONFIG;
+        /* NULLCLIENT requires SMARTHOST */
+        return EX_CONFIG;
 }
 
 bool is_configuration_setting_enabled(const char *identifier)
 {
-	struct config_item_t *item;
+        struct config_item_t *item;
 
-	if(identifier == NULL)
-		return false;
+        if (identifier == NULL)
+                return false;
 
-	SLIST_FOREACH(item, &config_head, next_item)
-		if(!strcmp(identifier, item->identifier))
-		{
-			/* Found the setting */
-			if(item->needs_value)
-			{
-				if(item->str_value != NULL)
-				{
-					last_checked_item = item;		/* Pointer to the last item that was queried
-													 * this is subsequently checked first,
-													 * if get_configuration_value() is called */
-					return true;
-				}
-				else
-					return false;
-			}
-			else
-			{
-				/* No value required, check if it is enabled */
-				if(item->str_value != NULL)
-					return true;
-				else
-					return false;
-			}
-		}
+        SLIST_FOREACH(item, &config_head, next_item)
+                if (!strcmp(identifier, item->identifier)) {
+                        /* Found the setting */
+                        if (!item->boolean_flag) {
+                                if (item->str_value != NULL) {
+                                        last_checked_item = item;
+                                        /* Pointer to the last item that was queried
+                                         * this is subsequently checked first,
+                                         * if get_configuration_value() is called */
+                                        return true;
+                                } else {
+                                        return false;
+                                }
+                        } else {
+                                /* No value required, check if it is enabled */
+                                if (item->str_value != NULL)
+                                        return true;
+                                else
+                                        return false;
+                        }
+                }
 
-	/* Not in list */
-	return false;
+        /* Not in list */
+        return false;
 }
 
-const char *get_configuration_value(const char *identifier)
+const char* get_configuration_value(const char *identifier)
 {
-	/*	* If isConfigurationFlagEnabled() has been called before,
-		* we'll try to use the item found there first */
-	struct config_item_t *item = NULL;
-	char *str_value = NULL;
+        /*	* If isConfigurationFlagEnabled() has been called before,
+         * we'll try to use the item found there first */
+        struct config_item_t *item = NULL;
+        char *str_value = NULL;
 
-	if(identifier == NULL)
-		return NULL;
+        if (identifier == NULL)
+                return NULL;
 
-	if(last_checked_item != NULL)
-	{
-		if(last_checked_item->str_value == NULL)
-			/* This really shouldn't happen */
-			errlogx(EX_DATAERR, "Internal data corruption"); /* exits */
+        if (last_checked_item != NULL) {
+                if (last_checked_item->str_value == NULL)
+                        /* This really shouldn't happen */
+                        errlogx(EX_DATAERR, "Internal data corruption"); /* exits */
 
-		if(!strcmp(last_checked_item->identifier, identifier))
-		{
-			str_value = last_checked_item->str_value;
-			last_checked_item = NULL; /* Reset */
-			return str_value;
-		}
-		else
-			/* last_checked_item led to a wrong item ... let's clear it */
-			last_checked_item = NULL;
-	}
-	/* Else we need to traverse the list */
-	SLIST_FOREACH(item, &config_head, next_item)
-		if(!strcmp(identifier, item->identifier))
-			return item->str_value;
+                if (!strcmp(last_checked_item->identifier, identifier)) {
+                        str_value = last_checked_item->str_value;
+                        last_checked_item = NULL; /* Reset */
+                        return str_value;
+                } else {
+                        /* last_checked_item led to a wrong item ... let's clear it */
+                        last_checked_item = NULL;
+                }
+        }
+        /* Else we need to traverse the list */
+        SLIST_FOREACH(item, &config_head, next_item)
+        if (!strcmp(identifier, item->identifier))
+                return item->str_value;
 
-	/* Not found */
-	return NULL;
+        /* Not found */
+        return NULL;
 }
 
 int add_auth_entry(char *user, char *domain, char *password)
 {
-	struct authuser *auth_item;
+        struct authuser *auth_item;
 
-	if(user == NULL || domain == NULL || password == NULL)
-		return EX_CONFIG;
+        if (user == NULL || domain == NULL || password == NULL)
+                return EX_CONFIG;
 
-	auth_item = malloc(sizeof(struct authuser));
-	if(auth_item == NULL)
-		return EX_OSERR;
+        auth_item = malloc(sizeof(struct authuser));
+        if (auth_item == NULL)
+                return EX_OSERR;
 
-	auth_item->login = user;
-	auth_item->host = domain;
-	auth_item->password = password;
+        auth_item->login = user;
+        auth_item->host = domain;
+        auth_item->password = password;
 
-	SLIST_INSERT_HEAD(&authusers, auth_item, next);
-	return 0;
-}
-
-void free_all_auth_entries(void)
-{
-	struct authuser *current_item;
-	struct authuser *next_item;
-
-	current_item = SLIST_FIRST(&authusers);
-	while (current_item != NULL)
-	{
-		next_item = SLIST_NEXT(current_item, next);
-
-		if(current_item->host != NULL)
-			free(current_item->host);
-		if(current_item->login != NULL)
-			free(current_item->login);
-		if(current_item->password != NULL)
-		{
-			/* Blank out the password before freeing
-			 *
-			 * Neither explicit_bzero nor memset_s are universally available
-			 * so we have to use memset and hope it's not optimized away
-			 */
-			memset(current_item->password, 0, strlen(current_item->password));
-			free(current_item->password);
-		}
-
-		free(current_item);
-		current_item = next_item;
-	}
-
-	SLIST_INIT(&authusers);
+        SLIST_INSERT_HEAD(&authusers, auth_item, next);
+        return 0;
 }
 
 #ifdef DEBUG_CONF
 static void print_configuration_settings(void)
 {
-	struct config_item_t *item;
+        struct config_item_t *item;
 
-	SLIST_FOREACH(item, &config_head, next_item) {
-		printf("ID: %s\tValue: %s\n", item->identifier, item->str_value);
-		printf("ID: %s\tValue: %s\n\n", item->identifier, is_configuration_setting_enabled(item->identifier) ? "true" : "false");
-	}
+        SLIST_FOREACH(item, &config_head, next_item) {
+                printf("ID: %s\tValue: %s\n", item->identifier, item->str_value);
+                printf("ID: %s\tValue: %s\n\n", item->identifier,
+                                is_configuration_setting_enabled(item->identifier) ?
+                                                "true" : "false");
+        }
 }
 #endif
 
 #ifdef DEBUG_CONF
 static void print_auth_items(void)
 {
-	struct authuser *item;
+        struct authuser *item;
 
-	SLIST_FOREACH(item, &authusers, next)
-		printf("User: '%s'\tHost: '%s'\tPassword: '%s'\n", item->login, item->host, item->password);
+        SLIST_FOREACH(item, &authusers, next)
+                printf("User: '%s'\tHost: '%s'\tPassword: '%s'\n", item->login, item->host,
+                                item->password);
 }
 #endif
 
-struct auth_details_t *get_auth_details_for_host(const char *host)
+struct auth_details_t* get_auth_details_for_host(const char *host)
 {
-	struct authuser *item;
-	struct auth_details_t *user_details;
+        struct authuser *item;
+        struct auth_details_t *user_details;
 
-	if(host == NULL)
-		return NULL;
+        if (host == NULL)
+                return NULL;
 
-	SLIST_FOREACH(item, &authusers, next)
-		if(strcmp(item->host, host) == 0)
-		{
-			user_details = malloc(sizeof(struct auth_details_t));
-			if(user_details == NULL)
-				return NULL;
+        SLIST_FOREACH(item, &authusers, next)
+                if (strcmp(item->host, host) == 0) {
+                        user_details = malloc(sizeof(struct auth_details_t));
+                        if (user_details == NULL)
+                                return NULL;
 
-			user_details->login = strdup(item->login);
-			user_details->password = strdup(item->password);
-			if(user_details->login == NULL || user_details->password == NULL)
-			{
-				free(user_details->login);
-				free(user_details->password);
-				free(user_details);
-				return NULL;
-			}
+                        user_details->login = strdup(item->login);
+                        user_details->password = strdup(item->password);
+                        if (user_details->login == NULL || user_details->password == NULL) {
+                                free(user_details->login);
+                                free(user_details->password);
+                                free(user_details);
+                                return NULL;
+                        }
 
-			return user_details;
-		}
+                        return user_details;
+                }
 
-	/* Not found */
-	return NULL;
+        /* Not found */
+        return NULL;
 }
 
 #ifdef DEBUG_CONF
 static void print_masquerade_settings(void)
 {
-	struct masquerade_config_t *masquerade = NULL;
+        struct masquerade_config_t *masquerade = NULL;
 
-	if(is_configuration_setting_enabled(CONF_MASQUERADE))
-	{
-		masquerade = extract_masquerade_settings(get_configuration_value(CONF_MASQUERADE));
-		if(masquerade != NULL)
-			printf("Masquerade Host: '%s'\tUser: '%s'\n", masquerade->host, masquerade->user);
-	}
-	if(masquerade != NULL)
-		free_masquerade_settings(masquerade);
+        if (is_configuration_setting_enabled(CONF_MASQUERADE)) {
+                masquerade = extract_masquerade_settings(
+                                get_configuration_value(CONF_MASQUERADE));
+                if (masquerade != NULL)
+                        printf("Masquerade Host: '%s'\tUser: '%s'\n", masquerade->host,
+                                        masquerade->user);
+        }
+        free_masquerade_settings(masquerade);
 }
 #endif

--- a/conf.c
+++ b/conf.c
@@ -46,6 +46,51 @@
 #define DP	": \t"
 #define EQS	" \t"
 
+/* Declarations of "private" types */
+
+typedef int (*check_ptr_t)(const char *, const char *);
+struct config_item_t {
+	check_ptr_t checkFunction;
+	char *identifier;
+	char *str_value;
+	bool needs_value;
+	SLIST_ENTRY(config_item_t) next_item;
+};
+SLIST_HEAD(S_CONFIGHEAD, config_item_t);
+
+struct authuser {
+	SLIST_ENTRY(authuser) next;
+	char *login;
+	char *password;
+	char *host;
+};
+SLIST_HEAD(authusers, authuser);
+
+/* Initializations */
+
+struct S_CONFIGHEAD config_head = SLIST_HEAD_INITIALIZER(config_head);
+struct authusers authusers = LIST_HEAD_INITIALIZER(authusers);
+bool is_configuration_initialized = false;
+
+struct config_item_t *last_checked_item = NULL;
+
+/* Static function declarations
+ * they are "private" (internal linkage) */
+
+static int check_fingerprint_configuration(const char *, const char *);
+static int check_nullclient_configuration(const char *, const char *);
+static void initialize_configuration_setting(const char*, check_ptr_t, bool, const char*);
+
+/* Debug Configuration */
+
+/*#define DEBUG_CONF*/
+
+#ifdef DEBUG_CONF
+static void print_configuration_settings(void);
+static void print_auth_items(void);
+static void print_masquerade_settings(void);
+#endif
+
 
 /*
  * Remove trailing \n's
@@ -71,16 +116,6 @@ trim_line(char *line)
 	}
 }
 
-static void
-chomp(char *str)
-{
-	size_t len = strlen(str);
-
-	if (len == 0)
-		return;
-	if (str[len - 1] == '\n')
-		str[len - 1] = 0;
-}
 
 /*
  * Read the SMTP authentication config file
@@ -93,168 +128,482 @@ chomp(char *str)
 void
 parse_authfile(const char *path)
 {
-	char line[2048];
-	struct authuser *au;
-	FILE *a;
-	char *data;
-	int lineno = 0;
-
-	a = fopen(path, "r");
-	if (a == NULL) {
+	auth_in = fopen(path, "r");
+	if (auth_in == NULL) {
 		errlog(EX_NOINPUT, "can not open auth file `%s'", path);
 		/* NOTREACHED */
 	}
 
-	while (!feof(a)) {
-		if (fgets(line, sizeof(line), a) == NULL)
-			break;
-		lineno++;
+	if(auth_parse())
+		errlog(EX_CONFIG, "syntax error in authfile '%s'", path);
+	fclose(auth_in);
 
-		chomp(line);
-
-		/* We hit a comment */
-		if (*line == '#')
-			continue;
-		/* Ignore empty lines */
-		if (*line == 0)
-			continue;
-
-		au = calloc(1, sizeof(*au));
-		if (au == NULL)
-			errlog(EX_OSERR, NULL);
-
-		data = strdup(line);
-		au->login = strsep(&data, "|");
-		au->host = strsep(&data, DP);
-		au->password = data;
-
-		if (au->login == NULL ||
-		    au->host == NULL ||
-		    au->password == NULL) {
-			errlogx(EX_CONFIG, "syntax error in authfile %s:%d", path, lineno);
-			/* NOTREACHED */
-		}
-
-		SLIST_INSERT_HEAD(&authusers, au, next);
-	}
-
-	fclose(a);
+#ifdef DEBUG_CONF
+	print_auth_items();
+#endif
 }
 
-/*
- * XXX TODO
- * Check for bad things[TM]
- */
 void
 parse_conf(const char *config_path)
 {
-	char *word;
-	char *data;
-	FILE *conf;
-	char line[2048];
-	int lineno = 0;
+	if(is_configuration_initialized == false)
+		errlogx(EX_SOFTWARE, "parse_conf must be run after initialize_all_configuration_settings()");
 
-	conf = fopen(config_path, "r");
-	if (conf == NULL) {
+	conf_in = fopen(config_path, "r");
+	if (conf_in == NULL) {
 		/* Don't treat a non-existing config file as error */
 		if (errno == ENOENT)
 			return;
 		errlog(EX_NOINPUT, "can not open config `%s'", config_path);
 		/* NOTREACHED */
 	}
+	if(conf_parse())
+		errlogx(EX_CONFIG, "Syntax error in config file '%s'", config_path);
 
-	while (!feof(conf)) {
-		if (fgets(line, sizeof(line), conf) == NULL)
+	fclose(conf_in);
+
+	/* NULLCLIENT configuration can only be checked once all config entries have been parsed */
+	if(is_configuration_setting_enabled(CONF_NULLCLIENT))
+		if(check_nullclient_configuration(CONF_NULLCLIENT, NULL) != 0)
+			errlogx(EX_CONFIG, "%s: NULLCLIENT requires SMARTHOST", config_path);
+
+#ifdef DEBUG_CONF
+	print_configuration_settings();
+	print_masquerade_settings();
+#endif
+}
+
+void initialize_all_configuration_settings(void)
+{
+	if(is_configuration_initialized != false)
+		/* This function shall only run once... */
+		return;
+
+	is_configuration_initialized = true;
+
+	SLIST_INIT(&config_head);
+
+	/* SMARTHOST */
+	initialize_configuration_setting(CONF_SMARTHOST, NULL, true, NULL);
+	/* PORT */
+	initialize_configuration_setting(CONF_PORT, NULL, true, SMTP_PORT_STRING);
+	/* and so on */
+	initialize_configuration_setting(CONF_ALIASES, NULL, true, DEFAULT_ALIASES_PATH);
+	initialize_configuration_setting(CONF_SPOOLDIR, NULL, true, DEFAULT_SPOOLDIR);
+	initialize_configuration_setting(CONF_AUTHPATH, NULL, true, NULL);
+	initialize_configuration_setting(CONF_CERTFILE, NULL, true, NULL);
+	initialize_configuration_setting(CONF_MAILNAME, NULL, true,  NULL);
+	initialize_configuration_setting(CONF_MASQUERADE, NULL, true, NULL);
+	initialize_configuration_setting(CONF_STARTTLS, NULL, false, NULL);
+	initialize_configuration_setting(CONF_FINGERPRINT, &check_fingerprint_configuration, true, NULL);
+	initialize_configuration_setting(CONF_TLS_OPP, NULL, false, NULL);
+	initialize_configuration_setting(CONF_SECURETRANSFER, NULL, false, NULL);
+	initialize_configuration_setting(CONF_DEFER, NULL, false, NULL);
+	initialize_configuration_setting(CONF_INSECURE, NULL, false, NULL);
+	initialize_configuration_setting(CONF_FULLBOUNCE, NULL, false, NULL);
+	initialize_configuration_setting(CONF_NULLCLIENT, NULL, false, NULL);
+}
+
+static void initialize_configuration_setting(
+		const char* identifier,
+		check_ptr_t func_ptr, bool needs_value,
+		const char* default_value
+		)
+{
+	struct config_item_t *item;
+
+	if(identifier == NULL)
+		return;
+
+	/* Check if the setting has already been initialized */
+	SLIST_FOREACH(item, &config_head, next_item)
+		if(!strcmp(identifier, item->identifier))
+			/* Already in list */
+			errlogx(EX_SOFTWARE, "Trying to initialize setting '%s' more than once", identifier);
+
+	item = calloc(1, sizeof(struct config_item_t));
+	if(item == NULL)
+		errlog(EX_OSERR,"Error allocating memory\n");
+		/* exit */
+
+	/* We use strdup() here so that we'll be able to properly clean up everything */
+	item->identifier = strdup(identifier);
+	item->checkFunction = func_ptr;
+	item->needs_value = needs_value;
+
+	if(default_value != NULL)
+		item->str_value = strdup(default_value);
+	else
+		item->str_value = NULL;
+
+	SLIST_INSERT_HEAD(&config_head, item, next_item);
+}
+
+int try_to_set_configuration_setting(char *identifier, char *value)
+{
+	struct config_item_t *item = NULL;
+	bool found = false;
+
+	SLIST_FOREACH(item, &config_head, next_item)
+		if(!strcmp(identifier, item->identifier))
+		{
+			found = true;
 			break;
-		lineno++;
+		}
 
-		chomp(line);
+	if(found)		/* item is pointing to the correct item now */
+	{
+		 /* Let's see if it requires a value */
+		if(item->needs_value)
+		{
+			/* Check values */
+			if(value == NULL)
+				/* Item requires a value, but no value has been provided! */
+				return EX_CONFIG;
 
-		/* We hit a comment */
-		if (strchr(line, '#'))
-			*strchr(line, '#') = 0;
+			/* Call the check function, if it exists */
+			if(item->checkFunction != NULL)
+				if(item->checkFunction(identifier, value) != 0)
+					return EX_CONFIG;
 
-		data = line;
-		word = strsep(&data, EQS);
+			/* Else let's store the value and return */
+			if(item->str_value != NULL)
+				free(item->str_value);	/* Let's free the old value first */
 
-		/* Ignore empty lines */
-		if (word == NULL || *word == 0)
-			continue;
+			item->str_value = value;
+			return 0;
+		}
+		else	/* No value needed */
+		{
+			/* Check if a value has been provided even though no value is expected */
+			if(value != NULL)
+				return EX_CONFIG;
 
-		if (data != NULL && *data != 0)
-			data = strdup(data);
-		else
-			data = NULL;
+			if(item->checkFunction != NULL)
+				if(item->checkFunction(identifier, value) != 0)
+					return EX_CONFIG;
 
-		if (strcmp(word, "SMARTHOST") == 0 && data != NULL)
-			config.smarthost = data;
-		else if (strcmp(word, "PORT") == 0 && data != NULL)
-			config.port = atoi(data);
-		else if (strcmp(word, "ALIASES") == 0 && data != NULL)
-			config.aliases = data;
-		else if (strcmp(word, "SPOOLDIR") == 0 && data != NULL)
-			config.spooldir = data;
-		else if (strcmp(word, "AUTHPATH") == 0 && data != NULL)
-			config.authpath= data;
-		else if (strcmp(word, "CERTFILE") == 0 && data != NULL)
-			config.certfile = data;
-		else if (strcmp(word, "MAILNAME") == 0 && data != NULL)
-			config.mailname = data;
-		else if (strcmp(word, "MASQUERADE") == 0 && data != NULL) {
-			char *user = NULL, *host = NULL;
-			if (strrchr(data, '@')) {
-				host = strrchr(data, '@');
-				*host = 0;
-				host++;
-				user = data;
-			} else {
-				host = data;
-			}
-			if (host && *host == 0)
-				host = NULL;
-                        if (user && *user == 0)
-                                user = NULL;
-			config.masquerade_host = host;
-			config.masquerade_user = user;
-		} else if (strcmp(word, "STARTTLS") == 0 && data == NULL)
-			config.features |= STARTTLS;
-		else if (strcmp(word, "FINGERPRINT") == 0) {
-			if (strlen(data) != SHA256_DIGEST_LENGTH * 2) {
-				errlogx(EX_CONFIG, "invalid sha256 fingerprint length");
-			}
-			unsigned char *fingerprint = malloc(SHA256_DIGEST_LENGTH);
-			if (fingerprint == NULL) {
-				errlogx(EX_CONFIG, "fingerprint allocation failed");
-			}
-			for (unsigned int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-				if(sscanf(data + 2 * i, "%02hhx", &fingerprint[i]) != 1) {
-					errlogx(EX_CONFIG, "failed to read fingerprint");
-				}
-			}
-			free(data);
-			config.fingerprint = fingerprint;
-		} else if (strcmp(word, "OPPORTUNISTIC_TLS") == 0 && data == NULL)
-			config.features |= TLS_OPP;
-		else if (strcmp(word, "SECURETRANSFER") == 0 && data == NULL)
-			config.features |= SECURETRANSFER;
-		else if (strcmp(word, "DEFER") == 0 && data == NULL)
-			config.features |= DEFER;
-		else if (strcmp(word, "INSECURE") == 0 && data == NULL)
-			config.features |= INSECURE;
-		else if (strcmp(word, "FULLBOUNCE") == 0 && data == NULL)
-			config.features |= FULLBOUNCE;
-		else if (strcmp(word, "NULLCLIENT") == 0 && data == NULL)
-			config.features |= NULLCLIENT;
-		else {
-			errlogx(EX_CONFIG, "syntax error in %s:%d", config_path, lineno);
-			/* NOTREACHED */
+			/* else let's set the config flag to on
+			 * we do not bother changing the value if it is already set,
+			 * as its concrete value is meaningless.
+			 * The value can already be set,
+			 * if its flag has been enabled more than once in the config file. */
+			if(item->str_value == NULL)
+				item->str_value = strdup("ON");
+			return 0;
 		}
 	}
+	else /* Item has not been found */
+		return EX_CONFIG;
+}
 
-	if ((config.features & NULLCLIENT) && config.smarthost == NULL) {
-		errlogx(EX_CONFIG, "%s: NULLCLIENT requires SMARTHOST", config_path);
-		/* NOTREACHED */
+void free_all_configuration_settings(void)
+{
+	struct config_item_t* current_item;
+	struct config_item_t* next_item;
+
+	last_checked_item = NULL;
+
+	current_item = SLIST_FIRST(&config_head);
+	while (current_item != NULL)
+	{
+		next_item = SLIST_NEXT(current_item, next_item);
+
+		if(current_item->identifier != NULL)
+			free(current_item->identifier);
+		if(current_item->str_value != NULL)
+			free(current_item->str_value);
+
+		free(current_item);
+		current_item = next_item;
+	}
+	SLIST_INIT(&config_head);
+}
+
+static int check_fingerprint_configuration(const char *identifier, const char *value)
+{
+	unsigned int counter;
+	unsigned char *fingerprint;
+
+	if(identifier == NULL || value == NULL)
+		return EX_CONFIG;
+
+	if(strlen(value) != SHA256_DIGEST_LENGTH * 2)
+		return EX_CONFIG;
+
+	fingerprint = malloc(SHA256_DIGEST_LENGTH);
+	if (fingerprint == NULL)
+		return EX_OSERR;
+
+	for (counter = 0; counter < SHA256_DIGEST_LENGTH; counter++)
+		if(sscanf(value + 2 * counter, "%02hhx", &fingerprint[counter]) != 1)
+		{
+			free(fingerprint);
+			return EX_CONFIG;
+		}
+
+	free(fingerprint);
+	return 0;
+}
+
+/* Helper function to return the masquerade settings split up in login and host */
+struct masquerade_config_t *extract_masquerade_settings(const char *value)
+{
+	char *user;
+	char *host;
+	char *copy_of_value;
+
+	struct masquerade_config_t *masquerade;
+
+#ifdef DEBUG_CONF
+	printf("extract_masquerade_settings called with value '%s'\n", value);
+#endif
+	copy_of_value = host = user = NULL;
+
+	if(value == NULL)
+		return NULL;
+
+	masquerade = malloc(sizeof(struct masquerade_config_t));
+
+	copy_of_value = strdup(value);
+
+	if(masquerade == NULL || copy_of_value == NULL)
+		return NULL;
+
+	host = strrchr(copy_of_value, '@');
+	if(host != NULL)
+	{
+		*host = '\0';
+		host++;
+		user = copy_of_value;
+	}
+	else
+		host = copy_of_value;
+
+	if(host != NULL && *host == '\0')
+		host = NULL;
+	if(user != NULL && *user == '\0')
+		user = NULL;
+
+	if(host != NULL)
+		masquerade->host = strdup(host);
+	else
+		masquerade->host = NULL;
+
+	if(user != NULL)
+		masquerade->user = strdup(user);
+	else
+		masquerade->user = NULL;
+
+#ifdef DEBUG_CONF
+	printf("masquerade_config.host: '%s'\tmasquerade_config.user: '%s'\n", masquerade->host, masquerade->user);
+#endif
+
+	free(copy_of_value);
+	return masquerade;;
+}
+
+static int check_nullclient_configuration(const char *identifier, const char *value)
+{
+	if(identifier == NULL || value != NULL)
+		errlogx(EX_SOFTWARE, "checkNullClientConfiguration called with invalid arguments.");
+
+	if(is_configuration_setting_enabled(CONF_SMARTHOST))
+		return 0;
+
+	/* NULLCLIENT requires SMARTHOST */
+	return EX_CONFIG;
+}
+
+bool is_configuration_setting_enabled(const char *identifier)
+{
+	struct config_item_t *item;
+
+	if(identifier == NULL)
+		return false;
+
+	SLIST_FOREACH(item, &config_head, next_item)
+		if(!strcmp(identifier, item->identifier))
+		{
+			/* Found the setting */
+			if(item->needs_value)
+			{
+				if(item->str_value != NULL)
+				{
+					last_checked_item = item;		/* Pointer to the last item that was queried
+													 * this is subsequently checked first,
+													 * if get_configuration_value() is called */
+					return true;
+				}
+				else
+					return false;
+			}
+			else
+			{
+				/* No value required, check if it is enabled */
+				if(item->str_value != NULL)
+					return true;
+				else
+					return false;
+			}
+		}
+
+	/* Not in list */
+	return false;
+}
+
+const char *get_configuration_value(const char *identifier)
+{
+	/*	* If isConfigurationFlagEnabled() has been called before,
+		* we'll try to use the item found there first */
+	struct config_item_t *item = NULL;
+	char *str_value = NULL;
+
+	if(identifier == NULL)
+		return NULL;
+
+	if(last_checked_item != NULL)
+	{
+		if(last_checked_item->str_value == NULL)
+			/* This really shouldn't happen */
+			errlogx(EX_DATAERR, "Internal data corruption"); /* exits */
+
+		if(!strcmp(last_checked_item->identifier, identifier))
+		{
+			str_value = last_checked_item->str_value;
+			last_checked_item = NULL; /* Reset */
+			return str_value;
+		}
+		else
+			/* last_checked_item led to a wrong item ... let's clear it */
+			last_checked_item = NULL;
+	}
+	/* Else we need to traverse the list */
+	SLIST_FOREACH(item, &config_head, next_item)
+		if(!strcmp(identifier, item->identifier))
+			return item->str_value;
+
+	/* Not found */
+	return NULL;
+}
+
+int add_auth_entry(char *user, char *domain, char *password)
+{
+	struct authuser *auth_item;
+
+	if(user == NULL || domain == NULL || password == NULL)
+		return EX_CONFIG;
+
+	auth_item = malloc(sizeof(struct authuser));
+	if(auth_item == NULL)
+		return EX_OSERR;
+
+	auth_item->login = user;
+	auth_item->host = domain;
+	auth_item->password = password;
+
+	SLIST_INSERT_HEAD(&authusers, auth_item, next);
+	return 0;
+}
+
+void free_all_auth_entries(void)
+{
+	struct authuser *current_item;
+	struct authuser *next_item;
+
+	current_item = SLIST_FIRST(&authusers);
+	while (current_item != NULL)
+	{
+		next_item = SLIST_NEXT(current_item, next);
+
+		if(current_item->host != NULL)
+			free(current_item->host);
+		if(current_item->login != NULL)
+			free(current_item->login);
+		if(current_item->password != NULL)
+		{
+			/* Blank out the password before freeing
+			 *
+			 * Neither explicit_bzero nor memset_s are universally available
+			 * so we have to use memset and hope it's not optimized away
+			 */
+			memset(current_item->password, 0, strlen(current_item->password));
+			free(current_item->password);
+		}
+
+		free(current_item);
+		current_item = next_item;
 	}
 
-	fclose(conf);
+	SLIST_INIT(&authusers);
 }
+
+#ifdef DEBUG_CONF
+static void print_configuration_settings(void)
+{
+	struct config_item_t *item;
+
+	SLIST_FOREACH(item, &config_head, next_item) {
+		printf("ID: %s\tValue: %s\n", item->identifier, item->str_value);
+		printf("ID: %s\tValue: %s\n\n", item->identifier, is_configuration_setting_enabled(item->identifier) ? "true" : "false");
+	}
+}
+#endif
+
+#ifdef DEBUG_CONF
+static void print_auth_items(void)
+{
+	struct authuser *item;
+
+	SLIST_FOREACH(item, &authusers, next)
+		printf("User: '%s'\tHost: '%s'\tPassword: '%s'\n", item->login, item->host, item->password);
+}
+#endif
+
+struct auth_details_t *get_auth_details_for_host(const char *host)
+{
+	struct authuser *item;
+	struct auth_details_t *user_details;
+
+	if(host == NULL)
+		return NULL;
+
+	SLIST_FOREACH(item, &authusers, next)
+		if(strcmp(item->host, host) == 0)
+		{
+			user_details = malloc(sizeof(struct auth_details_t));
+			if(user_details == NULL)
+				return NULL;
+
+			user_details->login = strdup(item->login);
+			user_details->password = strdup(item->password);
+			if(user_details->login == NULL || user_details->password == NULL)
+			{
+				free(user_details->login);
+				free(user_details->password);
+				free(user_details);
+				return NULL;
+			}
+
+			return user_details;
+		}
+
+	/* Not found */
+	return NULL;
+}
+
+#ifdef DEBUG_CONF
+static void print_masquerade_settings(void)
+{
+	struct masquerade_config_t *masquerade = NULL;
+
+	if(is_configuration_setting_enabled(CONF_MASQUERADE))
+	{
+		masquerade = extract_masquerade_settings(get_configuration_value(CONF_MASQUERADE));
+		if(masquerade != NULL)
+			printf("Masquerade Host: '%s'\tUser: '%s'\n", masquerade->host, masquerade->user);
+	}
+	if(masquerade != NULL)
+		free_masquerade_settings(masquerade);
+}
+#endif

--- a/conf_parse.y
+++ b/conf_parse.y
@@ -8,17 +8,17 @@ int conf_error(const char *);
 
 int conf_error(const char *s)
 {
-	extern char *conf_text;
+        extern char *conf_text;
 	
-	fprintf(stderr, "error %s at symbol: \"%s\" on line %d\n", s, conf_text, conf_lineno);
+        fprintf(stderr, "error %s at symbol: \"%s\" on line %d\n", s, conf_text, conf_lineno);
 	
-	return 0;
+        return 0;
 }
 %}
 
 %union
 {
-	char *str_type;
+        char *str_type;
 }
 
 /* declare tokens */
@@ -29,46 +29,45 @@ int conf_error(const char *s)
 %%
 
 settings: 
-		/* empty */
-	| settings setting		/* Main rule */
-	| settings empty_statement
-;
+        /* empty */
+        | settings setting              /* Main rule */
+        | settings empty_statement
+        ;
 
 setting: T_WORD newline
-	{
-		if(try_to_set_configuration_setting($1, NULL) != 0)
-		{
-			fprintf(stderr, "Line %d: '%s' invalid identifier or missing value\n",conf_lineno, $1);
-			free($1);
-			YYABORT;
-		}
-		else
+        {
+                if(try_to_set_configuration_setting($1, NULL) != 0) {
+                        fprintf(stderr, "Line %d: '%s' invalid identifier or missing value\n",conf_lineno, $1);
+                        free($1);
+                        YYABORT;
+                } else {
+                        free($1); /* Free the identifier */
+                }
+        }
+        | T_WORD blanks T_WORD newline
+        {
+                if(try_to_set_configuration_setting($1, $3) != 0) {
+                        fprintf(stderr, "Line %d: '%s' invalid identifier or value '%s'\n",conf_lineno,$1, $3);
+                        free($1);
+                        free($3);
+                        YYABORT;
+                } else {
 			free($1); /* Free the identifier */
-	}
-	| T_WORD blanks T_WORD newline
-	{
-		if(try_to_set_configuration_setting($1, $3) != 0)
-		{
-			fprintf(stderr, "Line %d: '%s' invalid identifier or value '%s'\n",conf_lineno,$1, $3);
-			free($1);
-			free($3);
-			YYABORT;
-		}
-		else
-			free($1); /* Free the identifier */
-	}
-;
+                }
+        }
+        ;
 
 blanks: T_BLANK
-	| blanks T_BLANK
-;
+        | blanks T_BLANK
+        ;
 
 newline: T_NEWLINE
-	| blanks T_NEWLINE
-;
+        | blanks T_NEWLINE
+        ;
 
 empty_statement: T_BLANK
-	| T_NEWLINE
-;
+        | T_NEWLINE
+        ;
 
 %%
+

--- a/conf_parse.y
+++ b/conf_parse.y
@@ -1,0 +1,74 @@
+%{
+#include <stdio.h>
+#include "dma.h"
+
+int conf_lex(void);
+extern int conf_lineno;
+int conf_error(const char *);
+
+int conf_error(const char *s)
+{
+	extern char *conf_text;
+	
+	fprintf(stderr, "error %s at symbol: \"%s\" on line %d\n", s, conf_text, conf_lineno);
+	
+	return 0;
+}
+%}
+
+%union
+{
+	char *str_type;
+}
+
+/* declare tokens */
+%token <str_type> T_WORD
+%token T_BLANK
+%token T_NEWLINE
+
+%%
+
+settings: 
+		/* empty */
+	| settings setting		/* Main rule */
+	| settings empty_statement
+;
+
+setting: T_WORD newline
+	{
+		if(try_to_set_configuration_setting($1, NULL) != 0)
+		{
+			fprintf(stderr, "Line %d: '%s' invalid identifier or missing value\n",conf_lineno, $1);
+			free($1);
+			YYABORT;
+		}
+		else
+			free($1); /* Free the identifier */
+	}
+	| T_WORD blanks T_WORD newline
+	{
+		if(try_to_set_configuration_setting($1, $3) != 0)
+		{
+			fprintf(stderr, "Line %d: '%s' invalid identifier or value '%s'\n",conf_lineno,$1, $3);
+			free($1);
+			free($3);
+			YYABORT;
+		}
+		else
+			free($1); /* Free the identifier */
+	}
+;
+
+blanks: T_BLANK
+	| blanks T_BLANK
+;
+
+newline: T_NEWLINE
+	| blanks T_NEWLINE
+;
+
+empty_statement: T_BLANK
+	| T_NEWLINE
+;
+
+%%

--- a/conf_scan.l
+++ b/conf_scan.l
@@ -10,25 +10,23 @@
 %option prefix="conf_"
 %option noyywrap
 
-WORD   			[^[:space:][:cntrl:]#]+
-BLANKS			[[:blank:]]+
+WORD	                [^[:space:][:cntrl:]#]+
+BLANKS                  [[:blank:]]+
 %%
 
-{WORD}							{ conf_lval.str_type = strdup(yytext); return T_WORD; }
+{WORD}                  { conf_lval.str_type = strdup(yytext); return T_WORD; }
 
 
-(#.*)+$							/*	ignore comments till the end of a line
-									we need to separately catch a new line in this case! */
+(#.*)+$			return T_NEWLINE; /*	ignore comments till the end of a line */
 									
-{BLANKS}						return T_BLANK;
+{BLANKS}		return T_BLANK;
 
-\\\r?\n							/* Ignore the newline if it's immediately preceeded by a backslash */
+\\\r?\n			/* Ignore the newline if it's immediately preceeded by a backslash */
 									
 
-^(\r?\n?[[:blank:]]*(#.*)?)+	return T_NEWLINE;  /*  ignore lines that are empty from the beginning
-													*(and optionally comments without anything
-													* but spaces before) */
-\r?\n							return T_NEWLINE;
-.								;
+
+\r?\n			return T_NEWLINE;
+.			;
 
 %%
+

--- a/conf_scan.l
+++ b/conf_scan.l
@@ -1,0 +1,34 @@
+%{
+
+#include <string.h>
+#include "conf_parse.h"
+
+%}
+
+%option yylineno
+%option noinput nounput
+%option prefix="conf_"
+%option noyywrap
+
+WORD   			[^[:space:][:cntrl:]#]+
+BLANKS			[[:blank:]]+
+%%
+
+{WORD}							{ conf_lval.str_type = strdup(yytext); return T_WORD; }
+
+
+(#.*)+$							/*	ignore comments till the end of a line
+									we need to separately catch a new line in this case! */
+									
+{BLANKS}						return T_BLANK;
+
+\\\r?\n							/* Ignore the newline if it's immediately preceeded by a backslash */
+									
+
+^(\r?\n?[[:blank:]]*(#.*)?)+	return T_NEWLINE;  /*  ignore lines that are empty from the beginning
+													*(and optionally comments without anything
+													* but spaces before) */
+\r?\n							return T_NEWLINE;
+.								;
+
+%%

--- a/dma.c
+++ b/dma.c
@@ -65,7 +65,9 @@ static void deliver(struct qitem *);
 
 struct aliases aliases = LIST_HEAD_INITIALIZER(aliases);
 struct strlist tmpfs = SLIST_HEAD_INITIALIZER(tmpfs);
-struct authusers authusers = LIST_HEAD_INITIALIZER(authusers);
+
+SSL *ssl_pointer = NULL;
+
 char username[USERNAME_SIZE];
 uid_t useruid;
 const char *logident_base;
@@ -73,21 +75,6 @@ char errmsg[ERRMSG_SIZE];
 
 static int daemonize = 1;
 static int doqueue = 0;
-
-struct config config = {
-	.smarthost	= NULL,
-	.port		= 25,
-	.aliases	= "/etc/aliases",
-	.spooldir	= "/var/spool/dma",
-	.authpath	= NULL,
-	.certfile	= NULL,
-	.features	= 0,
-	.mailname	= NULL,
-	.masquerade_host = NULL,
-	.masquerade_user = NULL,
-	.fingerprint = NULL,
-};
-
 
 static void
 sighup_handler(int signo)
@@ -100,9 +87,14 @@ set_from(struct queue *queue, const char *osender)
 {
 	const char *addr;
 	char *sender;
+	struct masquerade_config_t *masquerade_config = NULL;
 
-	if (config.masquerade_user) {
-		addr = config.masquerade_user;
+	if(is_configuration_setting_enabled(CONF_MASQUERADE))
+		masquerade_config = extract_masquerade_settings(get_configuration_value(CONF_MASQUERADE));
+
+
+	if (masquerade_config != NULL && masquerade_config->user != NULL) {
+		addr = masquerade_config->user;
 	} else if (osender) {
 		addr = osender;
 	} else if (getenv("EMAIL") != NULL) {
@@ -114,8 +106,8 @@ set_from(struct queue *queue, const char *osender)
 	if (!strchr(addr, '@')) {
 		const char *from_host = hostname();
 
-		if (config.masquerade_host)
-			from_host = config.masquerade_host;
+		if (masquerade_config != NULL && masquerade_config->host != NULL)
+			from_host = masquerade_config->host;
 
 		if (asprintf(&sender, "%s@%s", addr, from_host) <= 0)
 			return (NULL);
@@ -131,13 +123,21 @@ set_from(struct queue *queue, const char *osender)
 	}
 
 	queue->sender = sender;
+
+	if(masquerade_config != NULL)
+		free_masquerade_settings(masquerade_config);
 	return (sender);
 }
 
 static int
 read_aliases(void)
 {
-	yyin = fopen(config.aliases, "r");
+	const char *path = get_configuration_value(CONF_ALIASES);
+
+	if(path == NULL)
+		return (-1);
+
+	yyin = fopen(path, "r");
 	if (yyin == NULL) {
 		/*
 		 * Non-existing aliases file is not a fatal error
@@ -209,7 +209,7 @@ add_recp(struct queue *queue, const char *str, int expand)
 	 * Do local delivery if there is no @.
 	 * Do not do local delivery when NULLCLIENT is set.
 	 */
-	if (strrchr(it->addr, '@') == NULL && (config.features & NULLCLIENT) == 0) {
+	if (strrchr(it->addr, '@') == NULL && is_configuration_setting_enabled(CONF_NULLCLIENT) == false) {
 		it->remote = 0;
 		if (expand) {
 			aliased = do_alias(queue, it->addr);
@@ -453,8 +453,9 @@ main(int argc, char **argv)
 			errx(EX_OSERR, "cannot drop root privileges");
 	}
 
-	atexit(deltmp);
+	atexit(&cleanUp);
 	init_random();
+	initialize_all_configuration_settings();
 
 	bzero(&queue, sizeof(queue));
 	LIST_INIT(&queue.queue);
@@ -472,7 +473,7 @@ main(int argc, char **argv)
 		setlogident(NULL);
 
 		if (read_aliases() != 0)
-			errx(EX_SOFTWARE, "could not parse aliases file `%s'", config.aliases);
+			errx(EX_SOFTWARE, "could not parse aliases file `%s'", get_configuration_value(CONF_ALIASES));
 		exit(EX_OK);
 	}
 
@@ -578,8 +579,8 @@ skipopts:
 
 	parse_conf(CONF_PATH "/dma.conf");
 
-	if (config.authpath != NULL)
-		parse_authfile(config.authpath);
+	if (is_configuration_setting_enabled(CONF_AUTHPATH))
+		parse_authfile(get_configuration_value(CONF_AUTHPATH));
 
 	if (showq) {
 		if (load_queue(&queue) < 0)
@@ -596,14 +597,15 @@ skipopts:
 		return (0);
 	}
 
+
 	if (read_aliases() != 0)
-		errlog(EX_SOFTWARE, "could not parse aliases file `%s'", config.aliases);
+		errlog(EX_SOFTWARE, "could not parse aliases file `%s'", get_configuration_value(CONF_ALIASES));
 
 	if ((sender = set_from(&queue, sender)) == NULL)
 		errlog(EX_SOFTWARE, NULL);
 
 	if (newspoolf(&queue) != 0)
-		errlog(EX_CANTCREAT, "can not create temp file in `%s'", config.spooldir);
+		errlog(EX_CANTCREAT, "can not create temp file in `%s'", get_configuration_value(CONF_SPOOLDIR));
 
 	setlogident("%s", queue.id);
 
@@ -626,7 +628,7 @@ skipopts:
 
 	/* From here on the mail is safe. */
 
-	if (config.features & DEFER || queue_only)
+	if (is_configuration_setting_enabled(CONF_DEFER) || queue_only)
 		return (0);
 
 	run_queue(&queue);

--- a/dma.h
+++ b/dma.h
@@ -67,6 +67,9 @@
 #define CON_TIMEOUT	        (5*60)			/* Connection timeout per RFC5321 */
 #define DEFAULT_ALIASES_PATH    "/etc/aliases"
 #define DEFAULT_SPOOLDIR	"/var/spool/dma"
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX           255
+#endif
 
 /* String constants representing the configuration settings */
 
@@ -261,6 +264,7 @@ void errlog(int, const char *, ...) __attribute__((__format__ (__printf__, 2, 3)
 void errlogx(int, const char *, ...) __attribute__((__format__ (__printf__, 2, 3)));
 void free_auth_details(struct auth_details_t *);
 void free_masquerade_settings(struct masquerade_config_t *);
+void log_warning(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));;
 void set_username(void);
 void deltmp(void);
 int do_timeout(int, int);

--- a/dma.h
+++ b/dma.h
@@ -51,41 +51,41 @@
 
 /* Defaults */
 
-#define BUF_SIZE	2048
-#define ERRMSG_SIZE	1024
-#define USERNAME_SIZE	50
-#define EHLO_RESPONSE_SIZE BUF_SIZE
-#define MIN_RETRY	300				/* 5 minutes */
-#define MAX_RETRY	(3*60*60)		/* retry at least every 3 hours */
-#define MAX_TIMEOUT	(5*24*60*60)	/* give up after 5 days */
-#define SLEEP_TIMEOUT	30			/* check for queue flush every 30 seconds */
+#define BUF_SIZE	        2048
+#define ERRMSG_SIZE	        1024
+#define USERNAME_SIZE	        50
+#define EHLO_RESPONSE_SIZE      BUF_SIZE
+#define MIN_RETRY	        300			/* 5 minutes */
+#define MAX_RETRY	        (3*60*60)		/* retry at least every 3 hours */
+#define MAX_TIMEOUT	        (5*24*60*60)	        /* give up after 5 days */
+#define SLEEP_TIMEOUT	        30			/* check for queue flush every 30 seconds */
 #ifndef PATH_MAX
-#define PATH_MAX	1024			/* Max path len */
+#define PATH_MAX	        1024			/* Max path len */
 #endif
-#define	SMTP_PORT	25				/* Default SMTP port */
-#define SMTP_PORT_STRING			"25" /* as above, as string */
-#define CON_TIMEOUT	(5*60)			/* Connection timeout per RFC5321 */
-#define DEFAULT_ALIASES_PATH		"/etc/aliases"
-#define DEFAULT_SPOOLDIR			"/var/spool/dma"
+#define	SMTP_PORT	        25			/* Default SMTP port */
+#define SMTP_PORT_STRING        "25"                    /* as above, as string */
+#define CON_TIMEOUT	        (5*60)			/* Connection timeout per RFC5321 */
+#define DEFAULT_ALIASES_PATH    "/etc/aliases"
+#define DEFAULT_SPOOLDIR	"/var/spool/dma"
 
 /* String constants representing the configuration settings */
 
-#define CONF_STARTTLS				"STARTTLS"
-#define CONF_SECURETRANSFER			"SECURETRANSFER"
-#define CONF_DEFER					"DEFER"
-#define CONF_INSECURE				"INSECURE"
-#define CONF_FULLBOUNCE				"FULLBOUNCE"
-#define CONF_NULLCLIENT				"NULLCLIENT"
-#define CONF_TLS_OPP				"OPPORTUNISTIC_TLS"
-#define CONF_FINGERPRINT			"FINGERPRINT"
-#define CONF_MASQUERADE				"MASQUERADE"
-#define CONF_MAILNAME				"MAILNAME"
-#define CONF_CERTFILE				"CERTFILE"
-#define CONF_AUTHPATH				"AUTHPATH"
-#define CONF_SPOOLDIR				"SPOOLDIR"
-#define CONF_ALIASES				"ALIASES"
-#define CONF_PORT					"PORT"
-#define CONF_SMARTHOST				"SMARTHOST"
+#define CONF_STARTTLS		"STARTTLS"
+#define CONF_SECURETRANSFER	"SECURETRANSFER"
+#define CONF_DEFER		"DEFER"
+#define CONF_INSECURE		"INSECURE"
+#define CONF_FULLBOUNCE		"FULLBOUNCE"
+#define CONF_NULLCLIENT		"NULLCLIENT"
+#define CONF_TLS_OPP		"OPPORTUNISTIC_TLS"
+#define CONF_FINGERPRINT	"FINGERPRINT"
+#define CONF_MASQUERADE		"MASQUERADE"
+#define CONF_MAILNAME		"MAILNAME"
+#define CONF_CERTFILE		"CERTFILE"
+#define CONF_AUTHPATH		"AUTHPATH"
+#define CONF_SPOOLDIR		"SPOOLDIR"
+#define CONF_ALIASES		"ALIASES"
+#define CONF_PORT		"PORT"
+#define CONF_SMARTHOST		"SMARTHOST"
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH
@@ -95,17 +95,17 @@
 #error Please define LIBEXEC_PATH
 #endif
 
-#define SPOOL_FLUSHFILE	"flush"
+#define SPOOL_FLUSHFILE         "flush"
 
 #ifndef DMA_ROOT_USER
-#define DMA_ROOT_USER	"mail"
+#define DMA_ROOT_USER   	"mail"
 #endif
 #ifndef DMA_GROUP
-#define DMA_GROUP	"mail"
+#define DMA_GROUP	        "mail"
 #endif
 
 #ifndef MBOX_STRICT
-#define MBOX_STRICT	0
+#define MBOX_STRICT	        0
 #endif
 
 
@@ -177,7 +177,7 @@ extern bool no_ssl_flag;
 extern struct strlist tmpfs;
 extern char username[USERNAME_SIZE];
 extern uid_t useruid;
-extern SSL *ssl_pointer;
+extern SSL *ssl_state;
 extern const char *logident_base;
 
 extern char neterr[ERRMSG_SIZE];
@@ -195,7 +195,6 @@ int auth_parse(void);
 
 /* conf.c */
 /* "Public" functions */
-void free_all_configuration_settings(void);
 struct auth_details_t *get_auth_details_for_host(const char *);
 struct masquerade_config_t *extract_masquerade_settings(const char *);
 const char *get_configuration_value(const char *);
@@ -207,7 +206,6 @@ void initialize_all_configuration_settings(void);
 void trim_line(char *);
 int try_to_set_configuration_setting(char *, char *);
 int add_auth_entry(char *, char *, char *);
-void free_all_auth_entries(void);
 
 /* conf_parse.y */
 extern FILE *conf_in;
@@ -270,6 +268,5 @@ int open_locked(const char *, int, ...);
 char *rfc822date(void);
 int strprefixcmp(const char *, const char *);
 void init_random(void);
-void cleanUp(void);
 
 #endif

--- a/dma.h
+++ b/dma.h
@@ -45,31 +45,47 @@
 #include <openssl/ssl.h>
 #include <netdb.h>
 #include <sysexits.h>
+#include <stdbool.h>
 
 #define VERSION	"DragonFly Mail Agent " DMA_VERSION
+
+/* Defaults */
 
 #define BUF_SIZE	2048
 #define ERRMSG_SIZE	1024
 #define USERNAME_SIZE	50
 #define EHLO_RESPONSE_SIZE BUF_SIZE
-#define MIN_RETRY	300		/* 5 minutes */
-#define MAX_RETRY	(3*60*60)	/* retry at least every 3 hours */
+#define MIN_RETRY	300				/* 5 minutes */
+#define MAX_RETRY	(3*60*60)		/* retry at least every 3 hours */
 #define MAX_TIMEOUT	(5*24*60*60)	/* give up after 5 days */
-#define SLEEP_TIMEOUT	30		/* check for queue flush every 30 seconds */
+#define SLEEP_TIMEOUT	30			/* check for queue flush every 30 seconds */
 #ifndef PATH_MAX
-#define PATH_MAX	1024		/* Max path len */
+#define PATH_MAX	1024			/* Max path len */
 #endif
-#define	SMTP_PORT	25		/* Default SMTP port */
-#define CON_TIMEOUT	(5*60)		/* Connection timeout per RFC5321 */
+#define	SMTP_PORT	25				/* Default SMTP port */
+#define SMTP_PORT_STRING			"25" /* as above, as string */
+#define CON_TIMEOUT	(5*60)			/* Connection timeout per RFC5321 */
+#define DEFAULT_ALIASES_PATH		"/etc/aliases"
+#define DEFAULT_SPOOLDIR			"/var/spool/dma"
 
-#define STARTTLS	0x002		/* StartTLS support */
-#define SECURETRANSFER	0x004		/* SSL/TLS in general */
-#define NOSSL		0x008		/* Do not use SSL */
-#define DEFER		0x010		/* Defer mails */
-#define INSECURE	0x020		/* Allow plain login w/o encryption */
-#define FULLBOUNCE	0x040		/* Bounce the full message */
-#define TLS_OPP		0x080		/* Opportunistic STARTTLS */
-#define NULLCLIENT	0x100		/* Nullclient support */
+/* String constants representing the configuration settings */
+
+#define CONF_STARTTLS				"STARTTLS"
+#define CONF_SECURETRANSFER			"SECURETRANSFER"
+#define CONF_DEFER					"DEFER"
+#define CONF_INSECURE				"INSECURE"
+#define CONF_FULLBOUNCE				"FULLBOUNCE"
+#define CONF_NULLCLIENT				"NULLCLIENT"
+#define CONF_TLS_OPP				"OPPORTUNISTIC_TLS"
+#define CONF_FINGERPRINT			"FINGERPRINT"
+#define CONF_MASQUERADE				"MASQUERADE"
+#define CONF_MAILNAME				"MAILNAME"
+#define CONF_CERTFILE				"CERTFILE"
+#define CONF_AUTHPATH				"AUTHPATH"
+#define CONF_SPOOLDIR				"SPOOLDIR"
+#define CONF_ALIASES				"ALIASES"
+#define CONF_PORT					"PORT"
+#define CONF_SMARTHOST				"SMARTHOST"
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH
@@ -127,32 +143,10 @@ struct queue {
 	const char *sender;
 };
 
-struct config {
-	const char *smarthost;
-	int port;
-	const char *aliases;
-	const char *spooldir;
-	const char *authpath;
-	const char *certfile;
-	int features;
-	const char *mailname;
-	const char *masquerade_host;
-	const char *masquerade_user;
-	const unsigned char *fingerprint;
-
-	/* XXX does not belong into config */
-	SSL *ssl;
-};
-
-
-struct authuser {
-	SLIST_ENTRY(authuser) next;
-	char *login;
-	char *password;
+struct masquerade_config_t {
 	char *host;
+	char *user;
 };
-SLIST_HEAD(authusers, authuser);
-
 
 struct mx_hostentry {
 	char		host[MAXDNAME];
@@ -172,13 +166,18 @@ struct smtp_features {
 	int starttls;
 };
 
+struct auth_details_t {
+	char *login;
+	char *password;
+};
+
 /* global variables */
 extern struct aliases aliases;
-extern struct config config;
+extern bool no_ssl_flag;
 extern struct strlist tmpfs;
-extern struct authusers authusers;
 extern char username[USERNAME_SIZE];
 extern uid_t useruid;
+extern SSL *ssl_pointer;
 extern const char *logident_base;
 
 extern char neterr[ERRMSG_SIZE];
@@ -190,15 +189,34 @@ int yywrap(void);
 int yylex(void);
 extern FILE *yyin;
 
+/* auth_parse.y */
+extern FILE *auth_in;
+int auth_parse(void);
+
 /* conf.c */
-void trim_line(char *);
-void parse_conf(const char *);
+/* "Public" functions */
+void free_all_configuration_settings(void);
+struct auth_details_t *get_auth_details_for_host(const char *);
+struct masquerade_config_t *extract_masquerade_settings(const char *);
+const char *get_configuration_value(const char *);
+const struct masquerade_config_t *get_masquerade_settings(void);
+bool is_configuration_setting_enabled(const char *);
 void parse_authfile(const char *);
+void parse_conf(const char *);
+void initialize_all_configuration_settings(void);
+void trim_line(char *);
+int try_to_set_configuration_setting(char *, char *);
+int add_auth_entry(char *, char *, char *);
+void free_all_auth_entries(void);
+
+/* conf_parse.y */
+extern FILE *conf_in;
+int conf_parse(void);
 
 /* crypto.c */
 void hmac_md5(unsigned char *, int, unsigned char *, int, unsigned char *);
 int smtp_auth_md5(int, char *, char *);
-int smtp_init_crypto(int, int, struct smtp_features*);
+int smtp_init_crypto(int, struct smtp_features*);
 int verify_server_fingerprint(const X509 *);
 
 /* dns.c */
@@ -243,6 +261,8 @@ const char *hostname(void);
 void setlogident(const char *, ...) __attribute__((__format__ (__printf__, 1, 2)));
 void errlog(int, const char *, ...) __attribute__((__format__ (__printf__, 2, 3)));
 void errlogx(int, const char *, ...) __attribute__((__format__ (__printf__, 2, 3)));
+void free_auth_details(struct auth_details_t *);
+void free_masquerade_settings(struct masquerade_config_t *);
 void set_username(void);
 void deltmp(void);
 int do_timeout(int, int);
@@ -250,5 +270,6 @@ int open_locked(const char *, int, ...);
 char *rfc822date(void);
 int strprefixcmp(const char *, const char *);
 void init_random(void);
+void cleanUp(void);
 
 #endif

--- a/mail.c
+++ b/mail.c
@@ -99,7 +99,7 @@ bounce(struct qitem *it, const char *reason)
 		VERSION, hostname(),
 		it->addr,
 		reason,
-		config.features & FULLBOUNCE ?
+		is_configuration_setting_enabled(CONF_FULLBOUNCE) ?
 		    "Original message follows." :
 		    "Message headers follow.");
 	if (error < 0)
@@ -107,7 +107,7 @@ bounce(struct qitem *it, const char *reason)
 
 	if (fseek(it->mailf, 0, SEEK_SET) != 0)
 		goto fail;
-	if (config.features & FULLBOUNCE) {
+	if (is_configuration_setting_enabled(CONF_FULLBOUNCE)) {
 		while ((pos = fread(line, 1, sizeof(line), it->mailf)) > 0) {
 			if (fwrite(line, 1, pos, bounceq.mailf) != pos)
 				goto fail;

--- a/net.c
+++ b/net.c
@@ -95,10 +95,10 @@ send_remote_command(int fd, const char* fmt, ...)
 	strcat(cmd, "\r\n");
 	len = strlen(cmd);
 
-	if (((config.features & SECURETRANSFER) != 0) &&
-	    ((config.features & NOSSL) == 0)) {
-		while ((s = SSL_write(config.ssl, (const char*)cmd, len)) <= 0) {
-			s = SSL_get_error(config.ssl, s);
+	if (is_configuration_setting_enabled(CONF_SECURETRANSFER) == true &&
+	    no_ssl_flag == false) {
+		while ((s = SSL_write(ssl_pointer, (const char*)cmd, len)) <= 0) {
+			s = SSL_get_error(ssl_pointer, s);
 			if (s != SSL_ERROR_WANT_READ &&
 			    s != SSL_ERROR_WANT_WRITE) {
 				strlcpy(neterr, ssl_errstr(), sizeof(neterr));
@@ -148,9 +148,9 @@ read_remote(int fd, int extbufsize, char *extbuf)
 			memmove(buff, buff + pos, len - pos);
 			len -= pos;
 			pos = 0;
-			if (((config.features & SECURETRANSFER) != 0) &&
-			    (config.features & NOSSL) == 0) {
-				if ((rlen = SSL_read(config.ssl, buff + len, sizeof(buff) - len)) == -1) {
+			if (is_configuration_setting_enabled(CONF_SECURETRANSFER) == true &&
+					no_ssl_flag == false) {
+				if ((rlen = SSL_read(ssl_pointer, buff + len, sizeof(buff) - len)) == -1) {
 					strlcpy(neterr, ssl_errstr(), sizeof(neterr));
 					goto error;
 				}
@@ -270,8 +270,12 @@ smtp_login(int fd, char *login, char* password, const struct smtp_features* feat
 
 	// LOGIN
 	if (features->auth.login) {
-		if ((config.features & INSECURE) != 0 ||
-		    (config.features & SECURETRANSFER) != 0) {
+		/* old: if ((config.features & INSECURE) != 0 ||
+		 * (config.features & SECURETRANSFER) != 0)
+		 * does this combination make sense?
+		 */
+		if (is_configuration_setting_enabled(CONF_INSECURE) == true ||
+				is_configuration_setting_enabled(CONF_SECURETRANSFER) == true) {
 			/* Send AUTH command according to RFC 2554 */
 			send_remote_command(fd, "AUTH LOGIN");
 			if (read_remote(fd, 0, NULL) != 3) {
@@ -346,11 +350,11 @@ open_connection(struct mx_hostentry *h)
 static void
 close_connection(int fd)
 {
-	if (config.ssl != NULL) {
-		if (((config.features & SECURETRANSFER) != 0) &&
-		    ((config.features & NOSSL) == 0))
-			SSL_shutdown(config.ssl);
-		SSL_free(config.ssl);
+	if (ssl_pointer != NULL) {
+		if (is_configuration_setting_enabled(CONF_SECURETRANSFER) == true &&
+			no_ssl_flag == false)
+			SSL_shutdown(ssl_pointer);
+		SSL_free(ssl_pointer);
 	}
 
 	close(fd);
@@ -463,11 +467,11 @@ int perform_server_greeting(int fd, struct smtp_features* features) {
 static int
 deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
-	struct authuser *a;
 	struct smtp_features features;
+	struct auth_details_t *auth = NULL;
 	char line[1000], *addrtmp = NULL, *to_addr;
 	size_t linelen;
-	int fd, error = 0, do_auth = 0, res = 0;
+	int fd, error = 0, res = 0;
 
 	if (fseek(it->mailf, 0, SEEK_SET) != 0) {
 		snprintf(errmsg, sizeof(errmsg), "can not seek: %s", strerror(errno));
@@ -497,22 +501,22 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
         } while (0)
 
 	/* Check first reply from remote host */
-	if ((config.features & SECURETRANSFER) == 0 ||
-	    (config.features & STARTTLS) != 0) {
-		config.features |= NOSSL;
+	if (is_configuration_setting_enabled(CONF_SECURETRANSFER) == false ||
+			is_configuration_setting_enabled(CONF_STARTTLS) == true) {
+		no_ssl_flag = true;
 		READ_REMOTE_CHECK("connect", 2);
 
-		config.features &= ~NOSSL;
+		no_ssl_flag = false;
 	}
 
-	if ((config.features & SECURETRANSFER) != 0) {
-		error = smtp_init_crypto(fd, config.features, &features);
+	if (is_configuration_setting_enabled(CONF_SECURETRANSFER) == true) {
+		error = smtp_init_crypto(fd, &features);
 		if (error == 0)
 			syslog(LOG_DEBUG, "SSL initialization successful");
 		else
 			goto out;
 
-		if ((config.features & STARTTLS) == 0)
+		if (is_configuration_setting_enabled(CONF_STARTTLS) == false)
 			READ_REMOTE_CHECK("connect", 2);
 	}
 
@@ -527,20 +531,14 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	 * Use SMTP authentication if the user defined an entry for the remote
 	 * or smarthost
 	 */
-	SLIST_FOREACH(a, &authusers, next) {
-		if (strcmp(a->host, host->host) == 0) {
-			do_auth = 1;
-			break;
-		}
-	}
-
-	if (do_auth == 1) {
+	auth = get_auth_details_for_host(host->host);
+	if(auth != NULL) {
 		/*
 		 * Check if the user wants plain text login without using
 		 * encryption.
 		 */
-		syslog(LOG_INFO, "using SMTP authentication for user %s", a->login);
-		error = smtp_login(fd, a->login, a->password, &features);
+		syslog(LOG_INFO, "using SMTP authentication for user %s", auth->login);
+		error = smtp_login(fd, auth->login, auth->password, &features);
 		if (error < 0) {
 			syslog(LOG_ERR, "remote delivery failed:"
 					" SMTP login failed: %m");
@@ -611,6 +609,11 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 		syslog(LOG_INFO, "remote delivery succeeded but QUIT failed: %s", neterr);
 out:
 
+	if(auth != NULL)
+	{
+		free_auth_details(auth);
+		auth = NULL;
+	}
 	free(addrtmp);
 	close_connection(fd);
 	return (error);
@@ -627,9 +630,9 @@ deliver_remote(struct qitem *it)
 	port = SMTP_PORT;
 
 	/* Smarthost support? */
-	if (config.smarthost != NULL) {
-		host = config.smarthost;
-		port = config.port;
+	if (is_configuration_setting_enabled(CONF_SMARTHOST) == true) {
+		host = get_configuration_value(CONF_SMARTHOST);
+		port = atoi(get_configuration_value(CONF_PORT));
 		syslog(LOG_INFO, "using smarthost (%s:%i)", host, port);
 		smarthost = 1;
 	} else {

--- a/util.c
+++ b/util.c
@@ -60,21 +60,22 @@ hostname(void)
 	static char name[HOST_NAME_MAX+1];
 	static int initialized = 0;
 	char *s;
+	const char *mailname = get_configuration_value(CONF_MAILNAME);
 
 	if (initialized)
 		return (name);
 
-	if (config.mailname == NULL || !*config.mailname)
+	if (mailname == NULL || !*mailname)
 		goto local;
 
-	if (config.mailname[0] == '/') {
+	if (mailname[0] == '/') {
 		/*
 		 * If the mailname looks like an absolute path,
 		 * treat it as a file.
 		 */
 		FILE *fp;
 
-		fp = fopen(config.mailname, "r");
+		fp = fopen(mailname, "r");
 		if (fp == NULL)
 			goto local;
 
@@ -93,7 +94,7 @@ hostname(void)
 		initialized = 1;
 		return (name);
 	} else {
-		snprintf(name, sizeof(name), "%s", config.mailname);
+		snprintf(name, sizeof(name), "%s", mailname);
 		initialized = 1;
 		return (name);
 	}
@@ -345,4 +346,33 @@ init_random(void)
 
 	if (rf != -1)
 		close(rf);
+}
+
+void cleanUp(void)
+{
+	deltmp();
+	free_all_auth_entries();
+	free_all_configuration_settings();
+}
+
+void free_auth_details(struct auth_details_t *user_details)
+{
+	if(user_details == NULL)
+		return;
+
+	memset(user_details->password, 0, strlen(user_details->password));
+	free(user_details->login);
+	free(user_details->password);
+	free(user_details);
+}
+
+void free_masquerade_settings(struct masquerade_config_t *masquerade)
+{
+	if(masquerade == NULL)
+		return;
+	if(masquerade->user != NULL)
+		free(masquerade->user);
+	if(masquerade->host != NULL)
+		free(masquerade->host);
+	free(masquerade);
 }

--- a/util.c
+++ b/util.c
@@ -54,9 +54,6 @@
 const char *
 hostname(void)
 {
-#ifndef HOST_NAME_MAX
-#define HOST_NAME_MAX	255
-#endif
 	static char name[HOST_NAME_MAX+1];
 	static int initialized = 0;
 	char *s;
@@ -369,4 +366,29 @@ void free_masquerade_settings(struct masquerade_config_t *masquerade)
 	if(masquerade->host != NULL)
 		free(masquerade->host);
 	free(masquerade);
+}
+
+/* Copy of errlog[x] to print a warning in a consistent format
+ * as this is just a warning, it doesn't exit
+ */
+void log_warning(const char *fmt, ...)
+{
+        va_list ap;
+        char outs[ERRMSG_SIZE];
+
+        outs[0] = 0;
+        if (fmt != NULL) {
+                va_start(ap, fmt);
+                vsnprintf(outs, sizeof(outs), fmt, ap);
+                va_end(ap);
+        }
+
+        if (*outs != 0) {
+                syslog(LOG_WARNING, "%s", outs);
+                fprintf(stderr, "%s: %s\n", getprogname(), outs);
+        } else {
+                syslog(LOG_WARNING, "Unknown warning");
+                fprintf(stderr, "%s: Unknown warning\n", getprogname());
+        }
+
 }

--- a/util.c
+++ b/util.c
@@ -345,7 +345,8 @@ init_random(void)
 		close(rf);
 }
 
-void free_auth_details(struct auth_details_t *user_details)
+void
+free_auth_details(struct auth_details_t *user_details)
 {
 	if(user_details == NULL)
 		return;
@@ -356,22 +357,23 @@ void free_auth_details(struct auth_details_t *user_details)
 	free(user_details);
 }
 
-void free_masquerade_settings(struct masquerade_config_t *masquerade)
+void
+free_masquerade_settings(struct masquerade_config_t *masquerade)
 {
 	if(masquerade == NULL)
 		return;
 
-	if(masquerade->user != NULL)
-		free(masquerade->user);
-	if(masquerade->host != NULL)
-		free(masquerade->host);
+	free(masquerade->user);
+	free(masquerade->host);
 	free(masquerade);
 }
 
-/* Copy of errlog[x] to print a warning in a consistent format
- * as this is just a warning, it doesn't exit
+/*
+ * Copy of errlog resp errlogx to print a warning in a consistent format.
+ * Since this is supposed to be just a warning, it doesn't exit
  */
-void log_warning(const char *fmt, ...)
+void
+log_warning(const char *fmt, ...)
 {
         va_list ap;
         char outs[ERRMSG_SIZE];
@@ -383,12 +385,6 @@ void log_warning(const char *fmt, ...)
                 va_end(ap);
         }
 
-        if (*outs != 0) {
-                syslog(LOG_WARNING, "%s", outs);
-                fprintf(stderr, "%s: %s\n", getprogname(), outs);
-        } else {
-                syslog(LOG_WARNING, "Unknown warning");
-                fprintf(stderr, "%s: Unknown warning\n", getprogname());
-        }
-
+        syslog(LOG_WARNING, "%s", outs);
+        fprintf(stderr, "%s: %s\n", getprogname(), outs);
 }

--- a/util.c
+++ b/util.c
@@ -348,13 +348,6 @@ init_random(void)
 		close(rf);
 }
 
-void cleanUp(void)
-{
-	deltmp();
-	free_all_auth_entries();
-	free_all_configuration_settings();
-}
-
 void free_auth_details(struct auth_details_t *user_details)
 {
 	if(user_details == NULL)
@@ -370,6 +363,7 @@ void free_masquerade_settings(struct masquerade_config_t *masquerade)
 {
 	if(masquerade == NULL)
 		return;
+
 	if(masquerade->user != NULL)
 		free(masquerade->user);
 	if(masquerade->host != NULL)


### PR DESCRIPTION
Hello,

I've rewritten the configuration parsing to make use of simple lex/yacc parsers just as for the aliases file. Furthermore I've added reasonable data hiding so that the program uses a defined interface for accessing the config data.

Advantages:
* Modular design, the internals of the config settings may be changed without affecting the rest of the program
* Easy adding of new configuration settings
* Allows sanity checks of the parsed values through a check function for each configuration setting (at the moment implemented for the "FINGERPRINT" setting (this was already part of the code)). This could be enhanced to check for correct path names, read permissions, unreachable smarthosts, etc right when parsing the file.
* Reduce string manipulation

Implementation:
* The config settings are implemented using a singly-linked list, which should be fine for the current number of configuration settings. Should that number become considerably higher anytime in the future, the list can be changed to more sophisticated data structures, all while keeping the outside API.

I've kept the changes in the core code to a bare minimum, just made changes to make use of the "public" interface of the configuration parser.

If you like it, you're welcome to merge it. It's passed my tests, if you spot any errors though, I'll be happy to fix them.

PS: I've had to change the *BSD Makefile to be able to compile multiple lex/yacc files. It's not going to win any beauty-contest, but it's working on FreeBSD and Dragonfly BSD. Nonetheless any custom Makefiles for the *BSD ports-system would probably need to be changed as well.