### PR TITLE
Handle error return code of EHLO in STARTTLS.

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -159,6 +159,10 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features)
 					return (0);
 				}
 			}
+		} else {
+			syslog(LOG_ERR, "remote delivery deferred: could not perform server greeting: %s",
+				neterr);
+			return (1);
 		}
 
 		/* End of TLS init phase, enable SSL_write/read */


### PR DESCRIPTION
I was bitten by this and got very weird errors later in the TLS stuff.

Previous error:
Aug 16 20:06:52 freebsd13_py3 dma[3a0c1.800e48000][36135]: remote delivery deferred: SSL handshake failed fatally: error:1408F10B: SSL routines:ssl3_get_record:wrong version number

New error:
Aug 16 20:11:15 freebsd13_py3 dma[3a456.800e48000][37729]: remote delivery deferred: could not perform server greeting: 501 Syntactically invalid EHLO argument(s)

The cause of the error was an invalid hostname containing an _. At least this mailserver complained about it (Exim 4).