### PR TITLE
Implement header "From" rewriting

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -245,6 +245,8 @@ parse_conf(const char *config_path)
 			config.features |= FULLBOUNCE;
 		else if (strcmp(word, "NULLCLIENT") == 0 && data == NULL)
 			config.features |= NULLCLIENT;
+		else if (strcmp(word, "REWRITEFROM") == 0 && data == NULL)
+			config.features |= REWRITEFROM;
 		else {
 			errlogx(EX_CONFIG, "syntax error in %s:%d", config_path, lineno);
 			/* NOTREACHED */

--- a/dma.8
+++ b/dma.8
@@ -315,6 +315,9 @@ setting it to
 will send all mails as
 .Ql Sm off Va username @percolator .
 .Sm on
+.Pp
+You usually want to combine this setting with
+.Sq REWRITEFROM .
 .It Ic NULLCLIENT Xo
 (boolean, default=commented)
 .Xc
@@ -325,6 +328,11 @@ the defined
 requires
 .Sq SMARTHOST
 to be set.
+.It Ic REWRITEFROM Xo
+(boolean, default=commented)
+.Xc
+Rewrite the message header "From" address to the envelope-from address.
+The original unmodified header is added as "X-Original-From".
 .El
 .Ss Environment variables
 The behavior of

--- a/dma.conf
+++ b/dma.conf
@@ -58,7 +58,7 @@
 
 # Masquerade envelope from addresses with this address/hostname.
 # Use this if mails are not accepted by destination mail servers because
-# your sender domain is invalid.
+# your sender domain is invalid. You usually also want REWRITEFROM.
 # By default, MASQUERADE is not set.
 # Format: MASQUERADE [user@][host]
 # Examples:
@@ -68,3 +68,7 @@
 
 # Directly forward the mail to the SMARTHOST bypassing aliases and local delivery
 #NULLCLIENT
+
+# Rewrite the message header "From" address to the envelope-from address.
+# The original unmodified header is added as "X-Original-From".
+# REWRITEFROM

--- a/dma.h
+++ b/dma.h
@@ -52,6 +52,8 @@
 #define ERRMSG_SIZE	1024
 #define USERNAME_SIZE	50
 #define EHLO_RESPONSE_SIZE BUF_SIZE
+#define MSG_LINE_MAX	1000		/* maximum line length in a message, by RFC2822 */
+#define MSG_HDR_FROM_MAX 10*MSG_LINE_MAX /* maximum size of "From" header lines */
 #define MIN_RETRY	300		/* 5 minutes */
 #define MAX_RETRY	(3*60*60)	/* retry at least every 3 hours */
 #define MAX_TIMEOUT	(5*24*60*60)	/* give up after 5 days */
@@ -70,6 +72,7 @@
 #define FULLBOUNCE	0x040		/* Bounce the full message */
 #define TLS_OPP		0x080		/* Opportunistic STARTTLS */
 #define NULLCLIENT	0x100		/* Nullclient support */
+#define REWRITEFROM	0x200		/* rewrite header From to envelope from */
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH
@@ -119,12 +122,19 @@ struct qitem {
 };
 LIST_HEAD(queueh, qitem);
 
+struct msg_hdr {
+	char from_addr[MSG_LINE_MAX];
+	char from_lines[MSG_HDR_FROM_MAX];
+	char rewritten_from_lines[MSG_HDR_FROM_MAX];
+};
+
 struct queue {
 	struct queueh queue;
 	char *id;
 	FILE *mailf;
 	char *tmpf;
 	const char *sender;
+	struct msg_hdr header;
 };
 
 struct config {

--- a/mail.c
+++ b/mail.c
@@ -156,14 +156,18 @@ rewrite_header_from(struct msg_hdr *header, const char *sender)
 
 	if ( i == 0 ) {
 		syslog(LOG_INFO, "could not rewrite From in header");
-		strcpy(header->rewritten_from_lines, header->from_lines);
-		return (len_lines);
 	} else if ( (len_lines - len_addr) + strlen(sender) + 1 > MSG_HDR_FROM_MAX ) {
 		syslog(LOG_INFO, "could not rewrite From in header: rewritten lines too long");
-		strcpy(header->rewritten_from_lines, header->from_lines);
-		return (len_lines);
+		i = 0;
 	}
 
+	if ( i == 0 ) {
+		/* cannot rewrite so substitute with envelope-from anyway */
+		strcpy(stpcpy(stpcpy(header->rewritten_from_lines, "From: <"), sender), ">\n");
+		return (strlen(header->rewritten_from_lines));
+	}
+
+	/* do the rewrite */
 	strcpy(stpcpy(stpncpy(header->rewritten_from_lines,
 			header->from_lines, i),
 			sender),


### PR DESCRIPTION
This adds header From rewriting when enabled in dma.conf with REWRITEFROM.
The original From header is added as "X-Original-From".
The maximum length of the From header is limited to 10 lines as defined
by MSG_HDR_FROM_MAX due to static variable allocation.

The rewrite function fails if the address part of the From header is
not in a single line as it uses a simple strncmp. This could be improved
by refactoring parse_addrs() into a more generic address parsing
function that returns pointers to the start and end of a valid address
in the passed string, so the rewrite function could just replace the
string between those 2 pointers (inserting line continuations before and
after the address if the address happened to be split into multiple
lines). Nevertheless, the current simplified rewriting function will
fail gracefully in this case.

If the rewrite fails to find the From address in the header line,
the header is not rewritten, but X-Original-From is still added.
This can be changed via a later commit to on failure replace it with the
envelope-from address and discard the original From line. This will ensure
rewriting always takes place, but will not preserve the From address comment
sent by the client on failure to rewrite.