### PR TITLE
Fix compilation with older GCC versions

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -226,7 +226,8 @@ parse_conf(const char *config_path)
 			if (fingerprint == NULL) {
 				errlogx(EX_CONFIG, "fingerprint allocation failed");
 			}
-			for (unsigned int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+			unsigned int i;
+			for (i = 0; i < SHA256_DIGEST_LENGTH; i++) {
 				if(sscanf(data + 2 * i, "%02hhx", &fingerprint[i]) != 1) {
 					errlogx(EX_CONFIG, "failed to read fingerprint");
 				}


### PR DESCRIPTION
This is a minor change to fix compilation with older GCC versions that require to pass `-std=c99`, which if passed breaks many other things.