### PR TITLE
Replace from header function

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -246,7 +246,7 @@ parse_conf(const char *config_path)
 			config.features |= FULLBOUNCE;
 		else if (strcmp(word, "NULLCLIENT") == 0 && data == NULL)
 			config.features |= NULLCLIENT;
-        else if (strcmp(word, "REPLACEFROM") == 0 && data != NULL) {
+		else if (strcmp(word, "REPLACEFROM") == 0 && data != NULL) {
 			config.header_from_address = data;
 		}
 		else {

--- a/conf.c
+++ b/conf.c
@@ -246,6 +246,9 @@ parse_conf(const char *config_path)
 			config.features |= FULLBOUNCE;
 		else if (strcmp(word, "NULLCLIENT") == 0 && data == NULL)
 			config.features |= NULLCLIENT;
+        else if (strcmp(word, "REPLACEFROM") == 0 && data != NULL) {
+			config.header_from_address = data;
+		}
 		else {
 			errlogx(EX_CONFIG, "syntax error in %s:%d", config_path, lineno);
 			/* NOTREACHED */

--- a/dma.8
+++ b/dma.8
@@ -315,6 +315,9 @@ setting it to
 will send all mails as
 .Ql Sm off Va username @percolator .
 .Sm on
+.Pp
+It can be useful to combine this setting with
+.Sq REPLACEFROM .
 .It Ic NULLCLIENT Xo
 (boolean, default=commented)
 .Xc
@@ -325,6 +328,10 @@ the defined
 requires
 .Sq SMARTHOST
 to be set.
+.It Ic REPLACEFROM Xo
+(string, default=empty)
+.Xc
+Replace the message header "From" address with the given address.
 .El
 .Ss Environment variables
 The behavior of

--- a/dma.c
+++ b/dma.c
@@ -86,7 +86,7 @@ struct config config = {
 	.masquerade_host = NULL,
 	.masquerade_user = NULL,
 	.fingerprint = NULL,
-    .header_from_address = NULL,
+	.header_from_address = NULL,
 };
 
 

--- a/dma.c
+++ b/dma.c
@@ -86,6 +86,7 @@ struct config config = {
 	.masquerade_host = NULL,
 	.masquerade_user = NULL,
 	.fingerprint = NULL,
+    .header_from_address = NULL,
 };
 
 

--- a/dma.conf
+++ b/dma.conf
@@ -66,5 +66,10 @@
 # MASQUERADE percolator  will send mails as $username@percolator, e.g. fish@percolator
 # MASQUERADE herb@ert  will send all mails as herb@ert
 
+# Replace the message header "From" address with the given address.
+# Example:
+# REPLACEFROM user@domain.local
+
+
 # Directly forward the mail to the SMARTHOST bypassing aliases and local delivery
 #NULLCLIENT

--- a/dma.h
+++ b/dma.h
@@ -139,6 +139,7 @@ struct config {
 	const char *masquerade_host;
 	const char *masquerade_user;
 	const unsigned char *fingerprint;
+    const char *header_from_address;
 
 	/* XXX does not belong into config */
 	SSL *ssl;

--- a/dma.h
+++ b/dma.h
@@ -139,7 +139,7 @@ struct config {
 	const char *masquerade_host;
 	const char *masquerade_user;
 	const unsigned char *fingerprint;
-    const char *header_from_address;
+	const char *header_from_address;
 
 	/* XXX does not belong into config */
 	SSL *ssl;

--- a/mail.c
+++ b/mail.c
@@ -415,9 +415,9 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 				had_messagid = 1;
 			else if (strprefixcmp(line, "From:") == 0) {
 				had_from = 1;
-                if (config.header_from_address)
-                    snprintf(line, sizeof(line), "From: <%s>\n", config.header_from_address);
-            }
+				if (config.header_from_address)
+					snprintf(line, sizeof(line), "From: <%s>\n", config.header_from_address);
+			}
 			else if (strprefixcmp(line, "Bcc:") == 0)
 				nocopy = 1;
 
@@ -456,10 +456,10 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 						 hostname());
 				} else if (!had_from) {
 					had_from = 1;
-                    if (config.header_from_address)
-                        snprintf(line, sizeof(line), "From: <%s>\n", config.header_from_address);
-                    else
-					    snprintf(line, sizeof(line), "From: <%s>\n", queue->sender);
+					if (config.header_from_address)
+						snprintf(line, sizeof(line), "From: <%s>\n", config.header_from_address);
+					else
+						snprintf(line, sizeof(line), "From: <%s>\n", queue->sender);
 				}
 				if (fwrite(line, strlen(line), 1, queue->mailf) != 1)
 					return (-1);

--- a/mail.c
+++ b/mail.c
@@ -413,8 +413,11 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 				had_date = 1;
 			else if (strprefixcmp(line, "Message-Id:") == 0)
 				had_messagid = 1;
-			else if (strprefixcmp(line, "From:") == 0)
+			else if (strprefixcmp(line, "From:") == 0) {
 				had_from = 1;
+                if (config.header_from_address)
+                    snprintf(line, sizeof(line), "From: <%s>\n", config.header_from_address);
+            }
 			else if (strprefixcmp(line, "Bcc:") == 0)
 				nocopy = 1;
 
@@ -453,7 +456,10 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 						 hostname());
 				} else if (!had_from) {
 					had_from = 1;
-					snprintf(line, sizeof(line), "From: <%s>\n", queue->sender);
+                    if (config.header_from_address)
+                        snprintf(line, sizeof(line), "From: <%s>\n", config.header_from_address);
+                    else
+					    snprintf(line, sizeof(line), "From: <%s>\n", queue->sender);
 				}
 				if (fwrite(line, strlen(line), 1, queue->mailf) != 1)
 					return (-1);


### PR DESCRIPTION
I had the same problem as described in https://github.com/corecode/dma/issues/75. It has bugged me quite a few times and I saw the work already done by jjakob in https://github.com/corecode/dma/pull/96 and so I thought I'll give it a shot.

I have not coded C for a very long time, so I am not sure if this is the best way to do things. It works fine on my system now and I would be very happy if it could also help others. I'm happy to get feedback and would change the code as needed.

Basically this is the simplest form of fixing the error with cron etc.: If the `REPLACEFROM` setting is set in the config file (e.g.  `REPLACEFROM john@gmail.xyzasd`) then the header-from will always be replaced with the mail address passed in the config (even if there is no header-from existent at all). The old header-from (e.g. "From: root") is not saved anywhere.

PS: Not sure if I made the changes right in `dma.8`, never worked with that before.