### PR TITLE
Fix a memory leak in set_from()

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -126,6 +126,7 @@ set_from(struct queue *queue, const char *osender)
 	}
 
 	if (strchr(sender, '\n') != NULL) {
+		free(sender);
 		errno = EINVAL;
 		return (NULL);
 	}


### PR DESCRIPTION
Free the allocated 'sender' string when returning NULL on error.