### PR TITLE
Implement new DELIVERY config parameter.

### DIFF
--- a/dma.8
+++ b/dma.8
@@ -315,16 +315,20 @@ setting it to
 will send all mails as
 .Ql Sm off Va username @percolator .
 .Sm on
-.It Ic NULLCLIENT Xo
-(boolean, default=commented)
+.It Ic DELIVERY Xo
+(string, default=LOCALANDREMOTE)
 .Xc
-Bypass aliases and local delivery, and instead forward all mails to
-the defined
-.Sq SMARTHOST .
-.Sq NULLCLIENT
-requires
-.Sq SMARTHOST
-to be set.
+Type(s) of delivery that
+.Nm
+should perform.
+Set this to
+.Sq LOCALONLY
+to allow only deliveries to local recipients.
+Set it to
+.Sq REMOTEONLY
+to forward all messages to the defined
+.Sq SMARTHOST ,
+bypassing local aliases.
 .El
 .Ss Environment variables
 The behavior of

--- a/dma.conf
+++ b/dma.conf
@@ -66,5 +66,7 @@
 # MASQUERADE percolator  will send mails as $username@percolator, e.g. fish@percolator
 # MASQUERADE herb@ert  will send all mails as herb@ert
 
-# Directly forward the mail to the SMARTHOST bypassing aliases and local delivery
-#NULLCLIENT
+# Uncomment and set to LOCALONLY or REMOTEONLY if you want local-only or
+# remote-only delivery.  Note that remote-only mode requires SMARTHOST to
+# be specified, and ignores local aliases.
+#DELIVERY LOCALANDREMOTE

--- a/dma.h
+++ b/dma.h
@@ -69,7 +69,8 @@
 #define INSECURE	0x020		/* Allow plain login w/o encryption */
 #define FULLBOUNCE	0x040		/* Bounce the full message */
 #define TLS_OPP		0x080		/* Opportunistic STARTTLS */
-#define NULLCLIENT	0x100		/* Nullclient support */
+#define DELIVERY_LOCAL	0x100		/* Do local delivery */
+#define DELIVERY_REMOTE	0x200		/* Do remote delivery */
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH


### PR DESCRIPTION
Implementation of the feature discussed in #121.

Some remarks:

* I shortened "DELIVERYMODE" to "DELIVERY" for brevity;

* I fixed one unrelated bug along the way: specifying `FINGERPRINT` without an argument led to a segfault instead of an error;

* `NULLCLIENT` remains recognized in the config file, but I removed mention of it from the documentation as `DELIVERY REMOTEONLY` supersedes it.

Between this new parameter, use/absence of a smarthost, and a local (`user`) vs. remote (`user@host`) e-mail recipient address, there are a number of permutations of operation. The table below summarizes them, and the result:

| Address  | Smarthost? |   DELIVERY   |    Result       |
|----------|------------|--------------|-----------------|
|local|no|LOCALANDREMOTE|delivered locally|
|local|no|LOCALONLY|delivered locally|
|local|no|REMOTEONLY|error (SMARTHOST required, rc=78)|
|local|yes|LOCALANDREMOTE|delivered locally|
|local|yes|LOCALONLY|delivered locally|
|local|yes|REMOTEONLY|sent to SMARTHOST, bounce likely (rc=70)|
|remote|no|LOCALANDREMOTE|sent directly to address host|
|remote|no|LOCALONLY|error (invalid recipient, rc=65)|
|remote|no|REMOTEONLY|error (SMARTHOST required, rc=78)|
|remote|yes|LOCALANDREMOTE|sent to SMARTHOST|
|remote|yes|LOCALONLY|error (invalid recipient, rc=65)|
|remote|yes|REMOTEONLY|sent to SMARTHOST|

I used a script to test the various cases, which you might find useful for that purpose: [dma-delivery-test.sh.txt](https://github.com/corecode/dma/files/11305048/dma-delivery-test.sh.txt)