### PR TITLE
Fix building bsd/.. after using `make obj`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 *.o
-dma
-dma-mbox-create
-aliases_parse.c
-aliases_parse.h
-aliases_scan.c
+# Omit binaries.
+./dma
+./dma-mbox-create
+./aliases_parse.c
+./aliases_parse.h
+./aliases_scan.c
+# BSD-related...
+# - Omit files created on FreeBSD as part of bsd.prog.mk.
+*.depend
+*.debug
+*.full
+# - Omit files created in bsd if `make obj` isn't called first.
+bsd/dma/dma*
+bsd/dma-mbox-create/dma-mbox-create*

--- a/bsd/dma-mbox-create/Makefile
+++ b/bsd/dma-mbox-create/Makefile
@@ -1,6 +1,8 @@
 #
 
-version!=	sh ../../get-version.sh ../../VERSION
+DMA_SRCTOP=	${.CURDIR:H:H}
+
+.include "../version.mk"
 
 CFLAGS+= -I${.CURDIR}/../..
 CFLAGS+= -DHAVE_REALLOCF -DHAVE_STRLCPY -DHAVE_GETPROGNAME
@@ -8,7 +10,7 @@ CFLAGS+= -DLIBEXEC_PATH='"${LIBEXEC}"' -DDMA_VERSION='"${version}"'
 CFLAGS+= -DCONF_PATH='"${CONFDIR}"'
 
 PROG=	dma-mbox-create
-.PATH: ${.CURDIR}/../..
+.PATH: ${DMA_SRCTOP}
 SRCS+=	dma-mbox-create.c
 NOMAN=
 MK_MAN=	no

--- a/bsd/dma/Makefile
+++ b/bsd/dma/Makefile
@@ -1,7 +1,9 @@
 # $DragonFly: src/libexec/dma/Makefile,v 1.5 2008/09/19 00:36:57 corecode Exp $
 #
 
-version!=       sh ../../get-version.sh ../../VERSION
+DMA_SRCTOP=	${.CURDIR:H:H}
+
+.include "../version.mk"
 
 CFLAGS+= -I${.CURDIR}/../..
 CFLAGS+= -DHAVE_REALLOCF -DHAVE_STRLCPY -DHAVE_GETPROGNAME
@@ -12,7 +14,7 @@ DPADD=  ${LIBSSL} ${LIBCRYPTO}
 LDADD=  -lssl -lcrypto
 
 PROG=	dma
-.PATH: ${.CURDIR}/../..
+.PATH: ${DMA_SRCTOP}
 SRCS=	aliases_parse.y aliases_scan.l base64.c conf.c crypto.c
 SRCS+=	dma.c dns.c local.c mail.c net.c spool.c util.c
 MAN=	dma.8

--- a/bsd/version.mk
+++ b/bsd/version.mk
@@ -1,0 +1,3 @@
+SHELL?=		/bin/sh
+
+version!=	${SHELL} ${DMA_SRCTOP}/get-version.sh ${DMA_SRCTOP}/VERSION


### PR DESCRIPTION
Refer to source files using .CURDIR instead of relying on the build to be done with NO_OBJ, etc.

Adjust .gitignore to ignore files left behind as part of FreeBSD's bsd.prog.mk and to also prevent git from overzealously ignoring `bsd/dma{,-mbox-create}/...`.