### PR TITLE
Remove redundant check for SECURETRANSFER feature

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -40,6 +40,7 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 
+#include <assert.h>
 #include <strings.h>
 #include <string.h>
 #include <syslog.h>
@@ -141,10 +142,15 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features)
 	}
 
 	/*
+	 * If we are in smtp_init_crypto() that means SECURETRANSFER
+	 * must be set.
+	 */
+	assert((feature & SECURETRANSFER) != 0);
+
+	/*
 	 * If the user wants STARTTLS, we have to send EHLO here
 	 */
-	if (((feature & SECURETRANSFER) != 0) &&
-	     (feature & STARTTLS) != 0) {
+	if ((feature & STARTTLS) != 0) {
 		/* TLS init phase, disable SSL_write */
 		config.features |= NOSSL;
 


### PR DESCRIPTION
This is just a little quirk I noticed. I didn't see any other use of assert() in this codebase so feel free to reject the PR.