### PR TITLE
Verify smarthost's certificate

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -246,6 +246,8 @@ parse_conf(const char *config_path)
 			config.features |= FULLBOUNCE;
 		else if (strcmp(word, "NULLCLIENT") == 0 && data == NULL)
 			config.features |= NULLCLIENT;
+		else if (strcmp(word, "NOVERIFYCERT") == 0 && data == NULL)
+			config.features |= NOVERIFYCERT;
 		else {
 			errlogx(EX_CONFIG, "syntax error in %s:%d", config_path, lineno);
 			/* NOTREACHED */

--- a/conf.c
+++ b/conf.c
@@ -246,8 +246,8 @@ parse_conf(const char *config_path)
 			config.features |= FULLBOUNCE;
 		else if (strcmp(word, "NULLCLIENT") == 0 && data == NULL)
 			config.features |= NULLCLIENT;
-		else if (strcmp(word, "NOVERIFYCERT") == 0 && data == NULL)
-			config.features |= NOVERIFYCERT;
+		else if (strcmp(word, "VERIFYCERT") == 0 && data == NULL)
+			config.features |= VERIFYCERT;
 		else {
 			errlogx(EX_CONFIG, "syntax error in %s:%d", config_path, lineno);
 			/* NOTREACHED */

--- a/crypto.c
+++ b/crypto.c
@@ -103,7 +103,7 @@ verify_server_fingerprint(const X509 *cert)
 }
 
 int
-smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char *server_hostname, int smarthost)
+smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char *server_hostname)
 {
 	SSL_CTX *ctx = NULL;
 #if (OPENSSL_VERSION_NUMBER >= 0x00909000L)
@@ -143,7 +143,7 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char
 		}
 	}
 
-	verify_cert = smarthost && (!(config.features & NOVERIFYCERT));
+	verify_cert = config.features & VERIFYCERT;
 	if (verify_cert) {
 		int (*verify_cb)(int, X509_STORE_CTX *) = NULL;
 		int mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;

--- a/crypto.c
+++ b/crypto.c
@@ -195,7 +195,6 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char
 		return (1);
 	}
 
-
 	/* Only do SNI if hostname is not an IP address */
 	ip = a2i_IPADDRESS(server_hostname);
 	if (ip != NULL) {

--- a/crypto.c
+++ b/crypto.c
@@ -103,7 +103,7 @@ verify_server_fingerprint(const X509 *cert)
 }
 
 int
-smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char *server_hostname)
+smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char *server_hostname, int smarthost)
 {
 	SSL_CTX *ctx = NULL;
 #if (OPENSSL_VERSION_NUMBER >= 0x00909000L)
@@ -114,6 +114,7 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char
 	X509 *cert;
 	int error;
 	ASN1_OCTET_STRING *ip = NULL;
+	int verify_cert = 0;
 
 	/* XXX clean up on error/close */
 	/* Init SSL library */
@@ -138,6 +139,22 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char
 		error = init_cert_file(ctx, config.certfile);
 		if (error) {
 			syslog(LOG_WARNING, "remote delivery deferred");
+			return (1);
+		}
+	}
+
+	verify_cert = smarthost && (!(config.features & NOVERIFYCERT));
+	if (verify_cert) {
+		int (*verify_cb)(int, X509_STORE_CTX *) = NULL;
+		int mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+		/* NB: Don't change verify_cb */
+                verify_cb = SSL_CTX_get_verify_callback(ctx);
+		SSL_CTX_set_verify(ctx, mode, verify_cb);
+
+		error = SSL_CTX_set_default_verify_paths(ctx);
+		if (error == 0) {
+			syslog(LOG_NOTICE, "remote delivery deferred: SSL failed to set default CA path: %s",
+			       ssl_errstr());
 			return (1);
 		}
 	}
@@ -178,6 +195,7 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char
 		return (1);
 	}
 
+
 	/* Only do SNI if hostname is not an IP address */
 	ip = a2i_IPADDRESS(server_hostname);
 	if (ip != NULL) {
@@ -191,6 +209,35 @@ smtp_init_crypto(int fd, int feature, struct smtp_features* features, const char
 			syslog(LOG_NOTICE, "remote delivery deferred: SSL set TLS host name failed: %s",
 			       ssl_errstr());
 			return (1);
+		}
+	}
+
+	if (verify_cert) {
+		X509_VERIFY_PARAM *param = SSL_get0_param(config.ssl);
+
+		ip = a2i_IPADDRESS(server_hostname);
+		if (ip == NULL) {
+			ERR_clear_error();
+
+			error = X509_VERIFY_PARAM_set1_host(param, server_hostname,
+							    strlen(server_hostname));
+			if (error == 0) {
+				syslog(LOG_NOTICE, "remote delivery deferred: SSL set hostname check failed: %s",
+				       ssl_errstr());
+				return (1);
+			}
+		} else {
+			error = X509_VERIFY_PARAM_set1_ip(param, ASN1_STRING_get0_data(ip),
+							  ASN1_STRING_length(ip));
+
+			ASN1_OCTET_STRING_free(ip);
+			ip = NULL;
+
+			if (error == 0) {
+				syslog(LOG_NOTICE, "remote delivery deferred: SSL set ip check failed: %s",
+				       ssl_errstr());
+				return (1);
+			}
 		}
 	}
 

--- a/dma.conf
+++ b/dma.conf
@@ -21,6 +21,10 @@
 # Uncomment if you want TLS/SSL support
 #SECURETRANSFER
 
+# Disable verifying the smarthost's certificate (only used in combination
+# SECURETRANSFER).
+#NOVERIFYCERT
+
 # Uncomment if you want STARTTLS support (only used in combination with
 # SECURETRANSFER)
 #STARTTLS

--- a/dma.conf
+++ b/dma.conf
@@ -21,13 +21,13 @@
 # Uncomment if you want TLS/SSL support
 #SECURETRANSFER
 
-# Disable verifying the smarthost's certificate (only used in combination
-# SECURETRANSFER).
-#NOVERIFYCERT
-
 # Uncomment if you want STARTTLS support (only used in combination with
 # SECURETRANSFER)
 #STARTTLS
+
+# Verify the server certificate against the CA.
+# Only makes sense if you use a smarthost.
+#VERIFYCERT
 
 # Pin the server certificate by specifying its SHA256 fingerprint.
 # Only makes sense if you use a smarthost.

--- a/dma.h
+++ b/dma.h
@@ -70,7 +70,7 @@
 #define FULLBOUNCE	0x040		/* Bounce the full message */
 #define TLS_OPP		0x080		/* Opportunistic STARTTLS */
 #define NULLCLIENT	0x100		/* Nullclient support */
-#define NOVERIFYCERT	0x200		/* Verify remote host's certificate against CA */
+#define VERIFYCERT	0x200		/* Verify remote host's certificate against CA */
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH
@@ -199,7 +199,7 @@ void parse_authfile(const char *);
 /* crypto.c */
 void hmac_md5(unsigned char *, int, unsigned char *, int, unsigned char *);
 int smtp_auth_md5(int, char *, char *);
-int smtp_init_crypto(int, int, struct smtp_features*, const char *server_hostname, int smarthost);
+int smtp_init_crypto(int, int, struct smtp_features*, const char *server_hostname);
 
 /* dns.c */
 int dns_get_mx_list(const char *, int, struct mx_hostentry **, int);

--- a/dma.h
+++ b/dma.h
@@ -70,6 +70,7 @@
 #define FULLBOUNCE	0x040		/* Bounce the full message */
 #define TLS_OPP		0x080		/* Opportunistic STARTTLS */
 #define NULLCLIENT	0x100		/* Nullclient support */
+#define NOVERIFYCERT	0x200		/* Verify remote host's certificate against CA */
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH
@@ -198,7 +199,7 @@ void parse_authfile(const char *);
 /* crypto.c */
 void hmac_md5(unsigned char *, int, unsigned char *, int, unsigned char *);
 int smtp_auth_md5(int, char *, char *);
-int smtp_init_crypto(int, int, struct smtp_features*, const char *);
+int smtp_init_crypto(int, int, struct smtp_features*, const char *server_hostname, int smarthost);
 
 /* dns.c */
 int dns_get_mx_list(const char *, int, struct mx_hostentry **, int);

--- a/net.c
+++ b/net.c
@@ -474,7 +474,7 @@ int perform_server_greeting(int fd, struct smtp_features* features) {
 }
 
 static int
-deliver_to_host(struct qitem *it, struct mx_hostentry *host, int smarthost)
+deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 {
 	struct authuser *a;
 	struct smtp_features features;
@@ -519,7 +519,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host, int smarthost)
 	}
 
 	if ((config.features & SECURETRANSFER) != 0) {
-		error = smtp_init_crypto(fd, config.features, &features, host->host, smarthost);
+		error = smtp_init_crypto(fd, config.features, &features, host->host);
 		if (error == 0)
 			syslog(LOG_DEBUG, "SSL initialization successful");
 		else
@@ -668,7 +668,7 @@ deliver_remote(struct qitem *it)
 	}
 
 	for (h = hosts; *h->host != 0; h++) {
-		switch (deliver_to_host(it, h, smarthost)) {
+		switch (deliver_to_host(it, h)) {
 		case 0:
 			/* success */
 			error = 0;

--- a/net.c
+++ b/net.c
@@ -474,7 +474,7 @@ int perform_server_greeting(int fd, struct smtp_features* features) {
 }
 
 static int
-deliver_to_host(struct qitem *it, struct mx_hostentry *host)
+deliver_to_host(struct qitem *it, struct mx_hostentry *host, int smarthost)
 {
 	struct authuser *a;
 	struct smtp_features features;
@@ -519,7 +519,7 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	}
 
 	if ((config.features & SECURETRANSFER) != 0) {
-		error = smtp_init_crypto(fd, config.features, &features, host->host);
+		error = smtp_init_crypto(fd, config.features, &features, host->host, smarthost);
 		if (error == 0)
 			syslog(LOG_DEBUG, "SSL initialization successful");
 		else
@@ -668,7 +668,7 @@ deliver_remote(struct qitem *it)
 	}
 
 	for (h = hosts; *h->host != 0; h++) {
-		switch (deliver_to_host(it, h)) {
+		switch (deliver_to_host(it, h, smarthost)) {
 		case 0:
 			/* success */
 			error = 0;


### PR DESCRIPTION
Per #129 

After implementing the code I realized that the TLS code path is also invoked when connecting to MX hosts and not just smarthosts. In that case, I agree with you that forcing verification on MX hosts doesn't make much sense since that isn't under the user's control. I think verifying smarthosts by default always makes sense though so that's what I implemented here. Let me know what you think.

As an aside, the configuration option for STARTTLS should only apply to smarthosts as well, since you must use STARTTLS with MX hosts. I didn't implement that here, just noticed it. Maybe even more generally, the TLS options should only apply for the smarthost. For MX hosts, TLS should be used and verified on a per-domain basis (i.e. whitelist TLS for domains like gmail.com, yahoo.com, etc.) since we know those support TLS.