### PR TITLE
net.c: properly check result of vsnprintf() in 'send_remote_command()'

### DIFF
--- a/net.c
+++ b/net.c
@@ -51,8 +51,8 @@
 #include <err.h>
 #include <errno.h>
 #include <netdb.h>
-#include <setjmp.h>
-#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include <strings.h>
 #include <string.h>
 #include <syslog.h>
@@ -86,7 +86,7 @@ send_remote_command(int fd, const char* fmt, ...)
 	va_start(va, fmt);
 	s = vsnprintf(cmd, sizeof(cmd) - 2, fmt, va);
 	va_end(va);
-	if (s == sizeof(cmd) - 2 || s < 0) {
+	if (s < 0 || (size_t)s >= sizeof(cmd) - 2) {
 		strcpy(neterr, "Internal error: oversized command string");
 		return (-1);
 	}

--- a/net.c
+++ b/net.c
@@ -51,8 +51,8 @@
 #include <err.h>
 #include <errno.h>
 #include <netdb.h>
-#include <stdarg.h>
-#include <stdio.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <strings.h>
 #include <string.h>
 #include <syslog.h>


### PR DESCRIPTION
An excessively long remote command may get truncated by 'vsnprintf()' call in L87 which may go unnoticed by the incorrect check in L89 resulting in two bytes written beyond 'char cmd[4096]' array with 'strcat()' in L95 that assumes enough space was left in the buffer to append "\r\n"
