### PR TITLE
[Fix: #75] Cron mail is rejected due to missing domain.

### DIFF
--- a/mail.c
+++ b/mail.c
@@ -396,8 +396,11 @@ readmail(struct queue *queue, int nodot, int recp_from_header)
 			/*
 			 * Ignore a leading RFC-976 From_ or >From_ line mistakenly
 			 * inserted by some programs.
+			 * And also malformed cron "From: root (Cron Daemon)".
 			 */
-			if (strprefixcmp(line, "From ") == 0 || strprefixcmp(line, ">From ") == 0)
+			if (strprefixcmp(line, "From ")                    == 0 ||
+				strprefixcmp(line, ">From ")                   == 0 ||
+				strprefixcmp(line, "From: root (Cron Daemon)") == 0)
 				continue;
 			had_first_line = 1;
 		}


### PR DESCRIPTION
Drop the anyway malformed "From: root (Cron Daemon)" That cron daemon place by default at head of its messages.

Just like mistakenly inserted RFC-976 "From_" or ">From_" are already dropped.

When not removed, lot of modern mail delivery service will reject or silently drop the message.

Only some very new version of cron can change this behavior and it is not the default.
On old version there is nothing you can do.

When removed the expediter is available anyway by the mail envelop. Then no meaningful information is lost.