### PR TITLE
permit vertical bar as separator between smarthost and password

### DIFF
--- a/auth.conf
+++ b/auth.conf
@@ -2,3 +2,4 @@
 #
 # SMTP authentication entries
 # Format: user|my.smarthost.example.com:password
+# separator between smarthost and password may be (:| \t)

--- a/conf.c
+++ b/conf.c
@@ -43,7 +43,7 @@
 
 #include "dma.h"
 
-#define DP	": \t"
+#define DP	":| \t"
 #define EQS	" \t"
 
 


### PR DESCRIPTION
Currently the separator between SMTP username and smarthost is a vertical bar (`|`)and that between smarthost and password a colon (`:`).

This tiny patch permits using a verticar bar for both.