### PR TITLE
Support relaying to an LMTP endpoint

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -198,6 +198,8 @@ parse_conf(const char *config_path)
 			config.authpath= data;
 		else if (strcmp(word, "CERTFILE") == 0 && data != NULL)
 			config.certfile = data;
+		else if (strcmp(word, "LMTP") == 0 && data == NULL)
+			config.features |= LMTP;
 		else if (strcmp(word, "MAILNAME") == 0 && data != NULL)
 			config.mailname = data;
 		else if (strcmp(word, "MASQUERADE") == 0 && data != NULL) {
@@ -256,6 +258,11 @@ parse_conf(const char *config_path)
 
 	if ((config.features & NULLCLIENT) && config.smarthost == NULL) {
 		errlogx(EX_CONFIG, "%s: NULLCLIENT requires SMARTHOST", config_path);
+		/* NOTREACHED */
+	}
+
+	if ((config.features & LMTP) && (config.features & (TLS_OPP | STARTTLS | SECURETRANSFER))) {
+		errlogx(EX_CONFIG, "%s: LMTP does not support TLS", config_path);
 		/* NOTREACHED */
 	}
 

--- a/dma.h
+++ b/dma.h
@@ -71,6 +71,7 @@
 #define TLS_OPP		0x080		/* Opportunistic STARTTLS */
 #define NULLCLIENT	0x100		/* Nullclient support */
 #define VERIFYCERT	0x200		/* Verify remote host's certificate against CA */
+#define LMTP		0x300		/* Use LMTP instead of SMTP with the relay */
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH

--- a/dma.h
+++ b/dma.h
@@ -71,7 +71,7 @@
 #define TLS_OPP		0x080		/* Opportunistic STARTTLS */
 #define NULLCLIENT	0x100		/* Nullclient support */
 #define VERIFYCERT	0x200		/* Verify remote host's certificate against CA */
-#define LMTP		0x300		/* Use LMTP instead of SMTP with the relay */
+#define LMTP		0x400		/* Use LMTP instead of SMTP with the relay */
 
 #ifndef CONF_PATH
 #error Please define CONF_PATH

--- a/net.c
+++ b/net.c
@@ -390,7 +390,7 @@ int perform_server_greeting(int fd, struct smtp_features* features) {
 		Send EHLO
 		XXX allow HELO fallback
 	*/
-	send_remote_command(fd, "EHLO %s", hostname());
+	send_remote_command(fd, "%s %s", config.features & LMTP ? "LHLO" : "EHLO", hostname());
 
 	char buffer[EHLO_RESPONSE_SIZE];
 	memset(buffer, 0, sizeof(buffer));


### PR DESCRIPTION
This adds support for speaking LMTP to the relay. It's useful to bypass MTAs in case an LMTP-aware service, e.g., Dovecot, is running locally-ish.