### PR TITLE
log status line of remote host in case of successful delivery

### DIFF
--- a/net.c
+++ b/net.c
@@ -679,6 +679,9 @@ deliver_to_host(struct qitem *it, struct mx_hostentry *host)
 	READ_REMOTE_CHECK("final DATA", 2);
 	complete = 1;
 
+	syslog(LOG_INFO, "remote host %s [%s] said: %s",
+	       host->host, host->addr, neterr);
+
 out:
 	send_remote_command(fd, "QUIT");
 	if (read_remote(fd, 0, NULL) != 2)


### PR DESCRIPTION
After a successful remote delivery, I'd like dma to log the status line of the remote host which might contain helpful debugging hints, e.g. queue id assigned on the remote host.